### PR TITLE
 [Prompt] exposes provider field in `Prompt` type and populates it accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,15 @@ Use our [Maxim Langchain Tracer](https://www.npmjs.com/package/@maximai/maxim-js
 
 ## Version changelog
 
+### v6.4.0
+
+- feat: adds `provider` field to the `Prompt` type. This field specifies the LLM provider (e.g., 'openai', 'anthropic', etc.) for the prompt.
+
 ### v6.3.0
+
 - feat: adds attachments support to `Trace`, `Span`, and `Generation` for file uploads.
-	- 3 attachment types are supported: file path, buffer data, and URL
-	- has auto-detection of MIME types, file sizes, and names for attachments wherever possible
+  - 3 attachment types are supported: file path, buffer data, and URL
+  - has auto-detection of MIME types, file sizes, and names for attachments wherever possible
 - fix: refactored message handling for Generations to prevent keeping messages reference but rather duplicates the object to ensure point in time capture.
 - fix: ensures proper cleanup of resources
 
@@ -77,7 +82,7 @@ Use our [Maxim Langchain Tracer](https://www.npmjs.com/package/@maximai/maxim-js
 entity.addAttachment({
 	id: uuid(),
 	type: "file",
-	path: "/path/to/file.pdf"
+	path: "/path/to/file.pdf",
 });
 
 // Add buffer data as attachment
@@ -85,21 +90,23 @@ const buffer = fs.readFileSync("image.png");
 entity.addAttachment({
 	id: uuid(),
 	type: "fileData",
-	data: buffer
+	data: buffer,
 });
 
 // Add URL as attachment
 entity.addAttachment({
 	id: uuid(),
 	type: "url",
-	url: "https://example.com/image.jpg"
+	url: "https://example.com/image.jpg",
 });
 ```
 
 ### v6.2.2
+
 - fix: Added support for OpenAI's `logprobs` output in generation results (`ChatCompletionResult` and `TextCompletionResult`).
 
 ### v6.2.1
+
 - fix: Refactored message handling in Generation class to prevent duplicate messages
 
 ### v6.2.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.3.0",
+	"version": "6.4.0",
 	"devDependencies": {
 		"tslib": "2.6.3"
 	},

--- a/src/lib/maxim.ts
+++ b/src/lib/maxim.ts
@@ -397,6 +397,7 @@ export class Maxim {
 						messages: deployedVersion!.config?.messages,
 						modelParameters: deployedVersion!.config?.modelParameters,
 						model: deployedVersion!.config?.model,
+						provider: deployedVersion!.config?.provider,
 						tags: deployedVersion!.config?.tags,
 					} as Prompt;
 				}
@@ -420,6 +421,7 @@ export class Maxim {
 							messages: deployedVersion!.config?.messages,
 							modelParameters: deployedVersion!.config?.modelParameters,
 							model: deployedVersion!.config?.model,
+							provider: deployedVersion!.config?.provider,
 							tags: deployedVersion!.config?.tags,
 						} as Prompt;
 					}

--- a/src/lib/models/prompt.ts
+++ b/src/lib/models/prompt.ts
@@ -26,6 +26,7 @@ export type Prompt = {
 	messages: { role: string; content: string | CompletionRequestContent[] }[];
 	modelParameters: { [key: string]: any };
 	model: string;
+	provider: string;
 	tags: PromptTags;
 };
 


### PR DESCRIPTION
# Add provider field to Prompt type

This PR adds a new `provider` field to the `Prompt` type, which specifies the LLM provider (e.g., 'openai', 'anthropic', etc.) for the prompt. The field is now included when retrieving prompts from the platform.

The version has been bumped to v6.4.0 and the changelog has been updated to reflect this new feature.
