### PR TITLE
Add OpenTelemetry exporter for Vercel AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,30 @@ const toolResult = await tool.invoke(
 - **Automatic fallbacks**: If you don't provide custom names, the tracer uses sensible defaults based on the LangChain component names
 - **Session linking**: Use `sessionId` to group multiple traces under the same user session for better analytics
 
+### Vercel AI SDK
+
+Use Maxim's OpenTelemetry endpoint to capture AI SDK traces:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://api.getmaxim.ai/v1/otel \
+OTEL_EXPORTER_OTLP_HEADERS="x-maxim-api-key=<YOUR_API_KEY>,x-maxim-logger-id=<LOG_REPOSITORY_ID>"
+```
+
+Then enable telemetry when calling the AI SDK:
+
+```ts
+import { generateText } from "ai";
+import { initMaximOtel } from "@maximai/maxim-js";
+
+initMaximOtel({ apiKey: "<YOUR_API_KEY>", loggerId: "<LOG_REPOSITORY_ID>" });
+
+await generateText({
+        model,
+        prompt: "Hello",
+        experimental_telemetry: { isEnabled: true },
+});
+```
+
 ### Legacy Langchain Integration
 
 For projects still using our separate package [Maxim Langchain Tracer](https://www.npmjs.com/package/@maximai/maxim-js-langchain) (now deprecated in favor of the built-in tracer above), you can use our built-in tracer as is by just replacing the import and installing `@langchain/core`.

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ export * from "./src/lib/dataset/dataset";
 export * from "./src/lib/evaluators/evaluators";
 export * from "./src/lib/logger/components";
 export { MaximLangchainTracer } from "./src/lib/logger/langchain/tracer";
+export { initMaximOtel } from "./src/lib/logger/vercel/otel";
 export * from "./src/lib/logger/logger";
 export * from "./src/lib/maxim";
 export * from "./src/lib/models/cache";

--- a/package.json
+++ b/package.json
@@ -23,14 +23,20 @@
 		"copyfiles": "2.4.1",
 		"dotenv": "^16.5.0",
 		"eslint": "9.28.0",
-		"jest": "29.7.0",
-		"langchain": "^0.3.28",
-		"rimraf": "^6.0.1",
-		"ts-jest": "^29.3.4",
-		"tslib": "2.8.1",
-		"typescript": "5.8.3",
-		"uuid": "11.1.0"
-	},
+        "jest": "29.7.0",
+        "langchain": "^0.3.28",
+        "rimraf": "^6.0.1",
+        "ts-jest": "^29.3.4",
+        "tslib": "2.8.1",
+        "typescript": "5.8.3",
+        "uuid": "11.1.0",
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/sdk-node": "^0.45.0",
+        "@opentelemetry/sdk-trace-base": "^1.8.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.45.0",
+        "@opentelemetry/resources": "^1.8.0",
+        "@opentelemetry/semantic-conventions": "^1.8.0"
+        },
 	"peerDependencies": {
 		"@types/mime-types": "3.0.1",
 		"mime-types": "3.0.1"

--- a/src/lib/logger/vercel/otel.ts
+++ b/src/lib/logger/vercel/otel.ts
@@ -1,0 +1,41 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+
+export interface MaximOtelOptions {
+    /** Maxim log repository ID */
+    loggerId: string;
+    /** Maxim API key */
+    apiKey: string;
+    /** Custom service name for traces */
+    serviceName?: string;
+}
+
+/**
+ * Initializes OpenTelemetry tracing using Maxim's OTLP endpoint.
+ * Returns the started NodeSDK instance.
+ */
+export function initMaximOtel(options: MaximOtelOptions) {
+    const exporter = new OTLPTraceExporter({
+        url: "https://api.getmaxim.ai/v1/otel",
+        headers: {
+            "x-maxim-api-key": options.apiKey,
+            "x-maxim-logger-id": options.loggerId,
+        },
+    });
+
+    const sdk = new NodeSDK({
+        resource: new Resource({
+            [SemanticResourceAttributes.SERVICE_NAME]: options.serviceName ?? "maxim-vercel-ai",
+        }),
+    });
+
+    sdk.configureTracerProvider((provider) => {
+        provider.addSpanProcessor(new BatchSpanProcessor(exporter));
+    });
+
+    sdk.start();
+    return sdk;
+}


### PR DESCRIPTION
## Summary
- remove custom Vercel tracer implementation
- add OpenTelemetry helper to send AI SDK traces to Maxim
- document OTEL setup for Vercel AI SDK

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68539aed8a188320b5688115db24a6cf