### PR TITLE
[Logs] adds a new flow to upload large logs directly to remote storage for processing instead of sending those big payloads to sdk endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,15 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 
 ## Version changelog
 
+### v6.7.0
+
+- **feat**: Enhanced large log handling with automatic remote storage upload
+  - **NEW FEATURE**: Automatic detection of large logs (>900KB) and direct upload to remote storage instead of SDK endpoint
+  - **PERFORMANCE**: Significantly improved performance when logging large volumes of data by bypassing SDK payload limits
+  - **RELIABILITY**: Added retry mechanism (up to 3 attempts) for failed storage uploads
+  - **TRANSPARENCY**: Debug logging for large log upload operations with size and key information
+  - **AUTOMATIC**: No code changes required - large logs are automatically detected and handled via storage flow
+
 ### v6.6.0
 
 - **feat**: Added Vercel AI SDK integration

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.6.0",
+	"version": "6.7.0",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",

--- a/src/lib/apis/maxim.ts
+++ b/src/lib/apis/maxim.ts
@@ -28,15 +28,22 @@ export class MaximAPI {
 		return new Promise((resolve, reject) => {
 			const parsedUrl = new URL(this.baseUrl + relativeUrl);
 			const isLocalhost = parsedUrl.hostname === "localhost";
+
+			const requestHeaders: { [key: string]: string } = {
+				"x-maxim-api-key": this.apiKey,
+				...headers,
+			};
+
+			if (body) {
+				requestHeaders["Content-Length"] = Buffer.byteLength(body, "utf8").toString();
+			}
+
 			const options = {
 				hostname: parsedUrl.hostname,
 				port: isLocalhost ? parsedUrl.port || 3000 : 443,
 				path: parsedUrl.pathname + parsedUrl.search,
 				method: method ?? "GET",
-				headers: {
-					"x-maxim-api-key": this.apiKey,
-					...headers,
-				},
+				headers: requestHeaders,
 				// Use appropriate agent to ensure connections are closed
 				agent: isLocalhost ? this.httpAgent : this.httpsAgent,
 				// Set a timeout to ensure requests don't hang indefinitely

--- a/src/lib/logger/components/types.ts
+++ b/src/lib/logger/components/types.ts
@@ -28,6 +28,8 @@ export enum Entity {
 	TOOL_CALL = "tool_call",
 	/** Error or exception occurrence */
 	ERROR = "error",
+	/** Storage entity */
+	STORAGE = "storage",
 }
 
 /**


### PR DESCRIPTION
# Add Content-Length header and implement large log storage

This PR enhances the MaximAPI and logging system with two key improvements:

1. Added proper Content-Length header to API requests when a body is present, ensuring accurate request size information is transmitted to the server.

2. Implemented a large log storage mechanism that:
   - Detects logs exceeding ~900KB in size
   - Uploads oversized logs to storage with a unique UUID
   - Creates a reference log entry pointing to the stored content
   - Adds a new "STORAGE" entity type to track these large log references

The implementation includes retry logic for storage uploads (up to 3 attempts) and maintains the existing queue management system while accounting for the new storage queue.
