### PR TITLE
[Maxim] shifts from http to axios and implements retries for common server error (client errors are still rejected only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ logs/
 .temp/
 
 testConfig.json
-
+testRunTestConfig.json
+test.csv
 
 .env
 .env.beta

--- a/README.md
+++ b/README.md
@@ -469,6 +469,19 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 
 ## Version changelog
 
+### v6.8.0
+
+- **feat**: Migrated from native HTTP/HTTPS to Axios with comprehensive retry logic
+  - **BREAKING INTERNAL**: Replaced native Node.js `http`/`https` modules with `axios` and `axios-retry` for all API calls
+  - **RELIABILITY**: Enhanced retry mechanism with exponential backoff (up to 5 attempts) for server errors (5xx) and network issues
+  - **NETWORK RESILIENCE**: Automatic retries for common network errors (ECONNRESET, ETIMEDOUT, ENOTFOUND, etc.)
+  - **SMART RETRY**: Respects `Retry-After` headers and includes jitter to prevent thundering herd problems
+  - **ERROR HANDLING**: Client errors (4xx) are still immediately rejected without retries, preserving API contract
+  - **PERFORMANCE**: Improved connection pooling and keep-alive support for better throughput
+  - **TIMEOUT**: Enhanced timeout management with configurable per-request timeouts
+  - **DEBUGGING**: Better error logging and retry attempt tracking in debug mode
+  - **NEW DEPENDENCIES**: Added `axios` and `axios-retry` as direct dependencies
+
 ### v6.7.0
 
 - **feat**: Enhanced large log handling with automatic remote storage upload
@@ -708,7 +721,7 @@ No action needed for: Regular SDK usage through maxim.logger(), test runs, or pr
 - feat: adds attachments support to Trace, Span, and Generation for file uploads.
 - 3 attachment types are supported: file path, buffer data, and URL has auto-detection of MIME types, file sizes, and names for attachments wherever possible
 - fix: refactored message handling for Generations to prevent keeping messages reference but rather duplicates the object to ensure point in time capture.
-- fix: ensures proper cleanup of resources 
+- fix: ensures proper cleanup of resources
 
 ```js
 Adding attachments

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.7.0",
+	"version": "6.8.0",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",
@@ -80,5 +80,9 @@
 			"types": "./vercel-ai-sdk.d.ts",
 			"default": "./vercel-ai-sdk.js"
 		}
+	},
+	"dependencies": {
+		"axios": "^1.11.0",
+		"axios-retry": "^4.5.0"
 	}
 }

--- a/src/lib/apis/attachment.ts
+++ b/src/lib/apis/attachment.ts
@@ -2,8 +2,8 @@ import { MaximAPISignedURLResponse } from "../models/attachment";
 import { MaximAPI } from "./maxim";
 
 export class MaximAttachmentAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 
 	public async getUploadUrl(
@@ -11,66 +11,41 @@ export class MaximAttachmentAPI extends MaximAPI {
 		mimeType: string,
 		size: number,
 	): Promise<Extract<MaximAPISignedURLResponse, { data: unknown }>["data"]> {
-		return new Promise((resolve, reject) => {
-			this.fetch<MaximAPISignedURLResponse>(
-				`/api/sdk/v1/log-repositories/attachments/upload-url?key=${key}&mimeType=${mimeType}&size=${size}`,
-			)
-				.then((response) => {
-					if ("error" in response) {
-						reject(response.error);
-					} else {
-						resolve(response.data);
-					}
-				})
-				.catch((error) => {
-					reject(error);
-				});
-		});
+		const response = await this.fetch<MaximAPISignedURLResponse>(
+			`/api/sdk/v1/log-repositories/attachments/upload-url?key=${key}&mimeType=${mimeType}&size=${size}`,
+		);
+
+		if ("error" in response) {
+			throw response.error;
+		}
+
+		return response.data;
 	}
 
 	public async uploadToSignedUrl(url: string, data: Buffer, mimeType: string): Promise<void> {
-		// This is a direct upload to a signed URL, not a multipart upload
-		return new Promise((resolve, reject) => {
-			const parsedUrl = new URL(url);
-			const isLocalhost = parsedUrl.hostname === "localhost";
-			const requestModule = isLocalhost ? require("http") : require("https");
-
-			const makeRequest = (retryCount = 0) => {
-				const options = {
-					hostname: parsedUrl.hostname,
-					port: isLocalhost ? parsedUrl.port || 3000 : 443,
-					path: parsedUrl.pathname + parsedUrl.search,
-					method: "PUT",
-					headers: {
-						"Content-Type": mimeType,
-						"Content-Length": data.length,
-					},
-				};
-				const req = requestModule.request(options, (res: any) => {
-					if (res.statusCode >= 200 && res.statusCode < 300) {
-						resolve();
-					} else {
-						if (retryCount < 3) {
-							console.warn(`[MaximSDK] Upload failed with status ${res.statusCode}, retrying (${retryCount + 1}/3)...`);
-							makeRequest(retryCount + 1);
-						} else {
-							reject(new Error(`Failed to upload file: HTTP status ${res.statusCode} after 3 retries`));
-						}
-					}
-				});
-				req.on("error", (error: any) => {
-					if (retryCount < 3) {
-						console.warn(`[MaximSDK] Upload failed with error: ${error.message}, retrying (${retryCount + 1}/3)...`);
-						makeRequest(retryCount + 1);
-					} else {
-						reject(error);
-					}
-				});
-
-				req.write(data);
-				req.end();
-			};
-			makeRequest();
+		const response = await this.axiosInstance.put(url, data, {
+			headers: {
+				"Content-Type": mimeType,
+				"Content-Length": data.length.toString(),
+			},
+			responseType: "text",
+			timeout: 120000, // 2 minute timeout for large file uploads
+			// Don't transform the request/response to preserve binary data
+			transformRequest: [(data: Buffer) => data],
+			transformResponse: [(data: unknown) => data],
+			// Override base URL since this is a direct call to signed URL
+			baseURL: "",
 		});
+
+		// Success - axios retry already handled any retryable errors
+		if (response.status >= 200 && response.status < 300) {
+			return;
+		}
+
+		// This shouldn't happen due to axios retry, but just in case
+		if (response.data && typeof response.data === "object" && "error" in response.data) {
+			throw response.data.error;
+		}
+		throw response.data;
 	}
 }

--- a/src/lib/apis/dataset.ts
+++ b/src/lib/apis/dataset.ts
@@ -9,8 +9,8 @@ import { type MaximAPIResponse } from "../models/deployment";
 import { MaximAPI } from "./maxim";
 
 export class MaximDatasetAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 
 	public async addDatasetEntries(datasetId: string, datasetEntries: DatasetEntry[]): Promise<void> {

--- a/src/lib/apis/evaluator.ts
+++ b/src/lib/apis/evaluator.ts
@@ -3,8 +3,8 @@ import { ExtractAPIDataType } from "../utils/utils";
 import { MaximAPI } from "./maxim";
 
 export class MaximEvaluatorAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 
 	public async fetchPlatformEvaluator(name: string, inWorkspaceId: string): Promise<ExtractAPIDataType<MaximAPIEvaluatorFetchResponse>> {

--- a/src/lib/apis/folder.ts
+++ b/src/lib/apis/folder.ts
@@ -2,8 +2,8 @@ import { type Folder, type MaximFolderResponse, type MaximFoldersResponse } from
 import { MaximAPI } from "./maxim";
 
 export class MaximFolderAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 
 	public async getFolder(id: string): Promise<Folder> {

--- a/src/lib/apis/logs.ts
+++ b/src/lib/apis/logs.ts
@@ -3,8 +3,8 @@ import { MaximAPILogCheckAttachEvaluatorsResponse } from "../models/logger";
 import { MaximAPI } from "./maxim";
 
 export class MaximLogsAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 
 	public async doesLogRepositoryExist(loggerId: string): Promise<boolean> {
@@ -57,10 +57,10 @@ export class MaximLogsAPI extends MaximAPI {
 			this.fetch<MaximAPIResponse>(`/api/sdk/v3/log?id=${repositoryId}`, {
 				method: "POST",
 				headers: {
-					"Content-Type": "application/json",
-					Accept: "application/json",
+					"Content-Type": "text/plain",
 				},
 				body: logs,
+				responseType: "text",
 			})
 				.then((response) => {
 					if (response.error) {

--- a/src/lib/apis/prompt.ts
+++ b/src/lib/apis/prompt.ts
@@ -1,16 +1,16 @@
 import {
-	type MaximApiPromptResponse,
-	type MaximApiPromptsResponse,
-	type PromptVersionsAndRules,
-	type MaximApiPromptRunResponse,
-	type PromptResponse,
 	type ImageUrl,
+	type MaximApiPromptResponse,
+	type MaximApiPromptRunResponse,
+	type MaximApiPromptsResponse,
+	type PromptResponse,
+	type PromptVersionsAndRules,
 } from "../models/prompt";
 import { MaximAPI } from "./maxim";
 
 export class MaximPromptAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 
 	public async getPrompt(id: string): Promise<PromptVersionsAndRules> {

--- a/src/lib/apis/promptChain.ts
+++ b/src/lib/apis/promptChain.ts
@@ -1,15 +1,15 @@
 import {
+	type AgentResponse,
+	type MaximApiAgentRunResponse,
 	type MaximApiPromptChainResponse,
 	type MaximApiPromptChainsResponse,
 	type PromptChainVersionsAndRules,
-	type MaximApiAgentRunResponse,
-	type AgentResponse,
 } from "../models/promptChain";
 import { MaximAPI } from "./maxim";
 
 export class MaximPromptChainAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 
 	public async getPromptChain(id: string): Promise<PromptChainVersionsAndRules> {

--- a/src/lib/apis/testConfig.ts
+++ b/src/lib/apis/testConfig.ts
@@ -1,7 +1,7 @@
 import { MaximAPI } from "./maxim";
 
 export class MaximTestConfigAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 }

--- a/src/lib/apis/testRun.ts
+++ b/src/lib/apis/testRun.ts
@@ -2,10 +2,10 @@ import { MaximAPIResponse } from "../models/deployment";
 import { HumanEvaluationConfig, MaximAPIEvaluatorFetchResponse } from "../models/evaluator";
 import {
 	MaximAPICreateTestRunResponse,
-	MaximAPITestRunEntryExecutePromptForDataPayload,
-	MaximAPITestRunEntryExecutePromptForDataResponse,
 	MaximAPITestRunEntryExecutePromptChainForDataPayload,
 	MaximAPITestRunEntryExecutePromptChainForDataResponse,
+	MaximAPITestRunEntryExecutePromptForDataPayload,
+	MaximAPITestRunEntryExecutePromptForDataResponse,
 	MaximAPITestRunEntryExecuteWorkflowForDataPayload,
 	MaximAPITestRunEntryExecuteWorkflowForDataResponse,
 	MaximAPITestRunEntryPushPayload,
@@ -17,8 +17,8 @@ import { ExtractAPIDataType } from "../utils/utils";
 import { MaximAPI } from "./maxim";
 
 export class MaximTestRunAPI extends MaximAPI {
-	constructor(baseUrl: string, apiKey: string) {
-		super(baseUrl, apiKey);
+	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
+		super(baseUrl, apiKey, isDebug);
 	}
 
 	public async createTestRun(

--- a/src/lib/logger/writer.ts
+++ b/src/lib/logger/writer.ts
@@ -50,8 +50,8 @@ export class LogWriter {
 		this._raiseExceptions = config.raiseExceptions;
 		this.maxInMemoryLogs = config.maxInMemoryLogs || 100;
 		this.cache = config.cache;
-		this.logsAPIService = new MaximLogsAPI(config.baseUrl, config.apiKey);
-		this.attachmentAPIService = new MaximAttachmentAPI(config.baseUrl, config.apiKey);
+		this.logsAPIService = new MaximLogsAPI(config.baseUrl, config.apiKey, config.isDebug);
+		this.attachmentAPIService = new MaximAttachmentAPI(config.baseUrl, config.apiKey, config.isDebug);
 		if (config.autoFlush) {
 			this.flushInterval = setInterval(
 				() => {

--- a/src/lib/maxim.ts
+++ b/src/lib/maxim.ts
@@ -208,14 +208,14 @@ export class Maxim {
 		this.baseUrl = config.baseUrl || "https://app.getmaxim.ai";
 		this.apiKey = config.apiKey;
 		this._raiseExceptions = config.raiseExceptions || false;
-		this.APIService = {
-			prompt: new MaximPromptAPI(this.baseUrl, this.apiKey),
-			promptChain: new MaximPromptChainAPI(this.baseUrl, this.apiKey),
-			folder: new MaximFolderAPI(this.baseUrl, this.apiKey),
-			dataset: new MaximDatasetAPI(this.baseUrl, this.apiKey),
-			logs: new MaximLogsAPI(this.baseUrl, this.apiKey),
-		};
 		this.isDebug = config.debug || false;
+		this.APIService = {
+			prompt: new MaximPromptAPI(this.baseUrl, this.apiKey, this.isDebug),
+			promptChain: new MaximPromptChainAPI(this.baseUrl, this.apiKey, this.isDebug),
+			folder: new MaximFolderAPI(this.baseUrl, this.apiKey, this.isDebug),
+			dataset: new MaximDatasetAPI(this.baseUrl, this.apiKey, this.isDebug),
+			logs: new MaximLogsAPI(this.baseUrl, this.apiKey, this.isDebug),
+		};
 		this.cache = config.cache || new MaximInMemoryCache();
 		if (config.promptManagement) {
 			this.isPromptManagementEnabled = true;
@@ -773,10 +773,10 @@ export class Maxim {
 			}
 			await this.sync;
 			const key = this.getCacheKey(EntityType.PROMPT, promptId);
-			
+
 			// check if prompt is present in cache
 			let versionAndRules: PromptVersionsAndRules | null = await this.getPromptFromCache(key);
-			
+
 			// If not present in cache, we make an API call and set in cache
 			if (versionAndRules === null) {
 				versionAndRules = await this.APIService.prompt.getPrompt(promptId);
@@ -1224,7 +1224,14 @@ export class Maxim {
 	 *     ); // .with___(...)
 	 */
 	public createTestRun(name: string, inWorkspaceId: string): TestRunBuilder<undefined> {
-		return createTestRunBuilder({ baseUrl: this.baseUrl, apiKey: this.apiKey, name, workspaceId: inWorkspaceId, evaluators: [] });
+		return createTestRunBuilder({
+			baseUrl: this.baseUrl,
+			apiKey: this.apiKey,
+			name,
+			workspaceId: inWorkspaceId,
+			evaluators: [],
+			isDebug: this.isDebug,
+		});
 	}
 
 	/**

--- a/src/lib/models/testRun.ts
+++ b/src/lib/models/testRun.ts
@@ -264,6 +264,7 @@ export type TestRunResult = {
  * Configuration for a test run.
  */
 export type TestRunConfig<T extends DataStructure | undefined = undefined> = {
+	isDebug?: boolean;
 	baseUrl: string;
 	apiKey: string;
 	workspaceId: string;


### PR DESCRIPTION
# Modernize API client with axios and improve network resilience

This PR replaces the custom HTTP/HTTPS request implementation with axios for more robust networking:

- Added axios and axios-retry dependencies for improved HTTP client capabilities
- Implemented comprehensive retry logic with exponential backoff and jitter
- Enhanced error handling for network failures and server errors
- Optimized connection pooling with proper keep-alive settings
- Converted promise chains to async/await for better readability
- Updated content type for logs API to use text/plain
- Added test.csv and testRunTestConfig.json to .gitignore

The changes significantly improve reliability when dealing with network issues, timeouts, and server errors by automatically retrying failed requests with appropriate backoff strategies.
