### PR TITLE
[Prompts] introduces deploymentId in fetched prompts for azure provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,14 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 
 ## Version changelog
 
+### v6.9.0
+
+- **feat**: Added `deploymentId` support to prompt configurations
+  - **ENHANCEMENT**: Optional `deploymentId` field now available in `Prompt` and `PromptVersionConfig` types for all prompts with `Azure` provider
+- **improvement**: Extended mutex timeout for log processing from 30 seconds to 2 minutes
+  - **RELIABILITY**: Reduces timeout-related failures during heavy logging operations
+  - **PERFORMANCE**: Better handling of large log batches and concurrent operations
+
 ### v6.8.0
 
 - **feat**: Migrated from native HTTP/HTTPS to Axios with comprehensive retry logic
@@ -510,7 +518,9 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 ### v6.5.0
 
 - **⚠️ BREAKING CHANGES**:
+
   - **`Prompt.messages` type changed**: The `messages` field type has been updated for better type safety
+
     - **Before**: `{ role: string; content: string | CompletionRequestContent[] }[]`
     - **After**: `(CompletionRequest | ChatCompletionMessage)[]`
     - **Migration**: Update your code to use the new `CompletionRequest` interface which has more specific role types (`"user" | "system" | "tool" | "function"`) instead of generic `string`
@@ -626,6 +636,7 @@ entity.addAttachment({
 ```
 
 ### v6.5.0
+
 ⚠️ BREAKING CHANGES:
 
 Prompt.messages type changed: The messages field type has been updated for better type safety
@@ -636,7 +647,7 @@ Migration: Update your code to use the new CompletionRequest interface which has
 
 ```js
 // Before (v6.4.x and earlier)
-const messages: { role: string; content: string }[] = [{ role: "user", content: "Hello" }];
+const messages: { role: string, content: string }[] = [{ role: "user", content: "Hello" }];
 
 // After (v6.5.0+)
 const messages: CompletionRequest[] = [
@@ -713,6 +724,7 @@ No action needed for: Regular SDK usage through maxim.logger(), test runs, or pr
 ⚠️ Note: While these are technically breaking changes at the type level, most existing code will continue to work because CompletionRequest[] is compatible with (CompletionRequest | ChatCompletionMessage)[]. You may only see TypeScript compilation errors if you have strict type checking enabled.
 
 ## v6.4.0
+
 - feat: adds provider field to the Prompt type. This field specifies the LLM provider (e.g., 'openai', 'anthropic', etc.) for the prompt.
 - feat: include Langchain integration in the main repository
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.8.0",
+	"version": "6.9.0",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",

--- a/src/lib/logger/writer.ts
+++ b/src/lib/logger/writer.ts
@@ -427,7 +427,7 @@ export class LogWriter {
 			let items: CommitLog[] = [];
 
 			// Add a timeout to the mutex lock to prevent deadlocks
-			const MUTEX_TIMEOUT_MS = 30000; // 30 seconds
+			const MUTEX_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 
 			// Create a promise that resolves after the timeout
 			const timeoutPromise = new Promise<void>((_, reject) => {

--- a/src/lib/maxim.ts
+++ b/src/lib/maxim.ts
@@ -508,6 +508,7 @@ export class Maxim {
 						messages: deployedVersion!.config?.messages,
 						modelParameters: deployedVersion!.config?.modelParameters,
 						model: deployedVersion!.config?.model,
+						deploymentId: deployedVersion!.config?.deploymentId,
 						provider: deployedVersion!.config?.provider,
 						tags: deployedVersion!.config?.tags,
 						run: (input: string, options?: { imageUrls?: ImageUrl[]; variables?: { [key: string]: string } }) => {
@@ -538,6 +539,7 @@ export class Maxim {
 							messages: deployedVersion!.config?.messages,
 							modelParameters: deployedVersion!.config?.modelParameters,
 							model: deployedVersion!.config?.model,
+							deploymentId: deployedVersion!.config?.deploymentId,
 							provider: deployedVersion!.config?.provider,
 							tags: deployedVersion!.config?.tags,
 							run: (input: string, options?: { imageUrls?: ImageUrl[]; variables?: { [key: string]: string } }) => {

--- a/src/lib/models/prompt.ts
+++ b/src/lib/models/prompt.ts
@@ -234,6 +234,7 @@ export type Prompt = {
 	messages: (CompletionRequest | ChatCompletionMessage)[];
 	modelParameters: { [key: string]: any };
 	model: string;
+	deploymentId?: string;
 	provider: string;
 	tags: PromptTags;
 	run: (input: string, options?: { imageUrls?: ImageUrl[]; variables?: { [key: string]: string } }) => Promise<PromptResponse>;
@@ -249,6 +250,7 @@ export type PromptVersionConfig = {
 	modelParameters: { [key: string]: any };
 	model: string;
 	provider: string;
+	deploymentId?: string;
 	tags?: PromptTagValues;
 };
 


### PR DESCRIPTION
# Added Azure deploymentId support and improved log processing reliability

This PR introduces two key improvements:

1. **Azure OpenAI Support Enhancement**: Added `deploymentId` field to prompt configurations
   - New optional field in `Prompt` and `PromptVersionConfig` types
   - Enables specifying Azure-specific deployment IDs when using the Azure provider

2. **Log Processing Reliability**: Extended mutex timeout for log processing from 30 seconds to 2 minutes
   - Reduces timeout-related failures during heavy logging operations
   - Improves handling of large log batches and concurrent operations

Version bumped to 6.9.0 with updated changelog.
