### PR TITLE
Updated the add datset entries function to handle files, chnaged previous type DatasetEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,11 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 
 ## Version changelog
 
-### v6.9.1
+### v6.10.0
 
+- **feat**: v4 datasets API; flattened POST (rowNo, columnName, type, cellValue) and two-step file upload + PATCH
+- **feat**: signed URL helpers (`getUploadUrlForDatasetAttachment`, `uploadToSignedUrl`)
+- **feat**: `addDatasetEntries` now takes `[{ columnName, cellValue: { type: VariableType.TEXT | VariableType.JSON | VariableType.FILE, payload } }]`
 - **fix**: Fixed the usage type for `PromptResponse` and `PromptChainResponse` to respond with camel-case instead of snake-case
 
 ### v6.9.0
@@ -616,132 +619,6 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 **Adding attachments**
 
 ```js
-// Add file as attachment
-entity.addAttachment({
-	id: uuid(),
-	type: "file",
-	path: "/path/to/file.pdf",
-});
-
-// Add buffer data as attachment
-const buffer = fs.readFileSync("image.png");
-entity.addAttachment({
-	id: uuid(),
-	type: "fileData",
-	data: buffer,
-});
-
-// Add URL as attachment
-entity.addAttachment({
-	id: uuid(),
-	type: "url",
-	url: "https://example.com/image.jpg",
-});
-```
-
-### v6.5.0
-
-⚠️ BREAKING CHANGES:
-
-Prompt.messages type changed: The messages field type has been updated for better type safety
-
-Before: { role: string; content: string | CompletionRequestContent[] }[]
-After: (CompletionRequest | ChatCompletionMessage)[]
-Migration: Update your code to use the new CompletionRequest interface which has more specific role types ("user" | "system" | "tool" | "function") instead of generic string
-
-```js
-// Before (v6.4.x and earlier)
-const messages: { role: string, content: string }[] = [{ role: "user", content: "Hello" }];
-
-// After (v6.5.0+)
-const messages: CompletionRequest[] = [
-	{ role: "user", content: "Hello" }, // role is now type-safe
-];
-```
-
-GenerationConfig.messages type changed: For better type safety and tool call support
-
-Before: messages: CompletionRequest[]
-After: messages: (CompletionRequest | ChatCompletionMessage)[]
-Migration: Your existing CompletionRequest[] arrays will still work, but you can now also pass ChatCompletionMessage[] for assistant responses with tool calls
-Generation.addMessages() method signature changed:
-
-Before: addMessages(messages: CompletionRequest[])
-After: addMessages(messages: (CompletionRequest | ChatCompletionMessage)[])
-Migration: Your existing calls will still work, but you can now also pass assistant messages with tool calls
-MaximLogger.generationAddMessage() method signature changed:
-
-Before: generationAddMessage(generationId: string, messages: CompletionRequest[])
-After: generationAddMessage(generationId: string, messages: (CompletionRequest | ChatCompletionMessage)[])
-Migration: Your existing calls will still work, but you can now also pass assistant messages with tool calls
-feat: Added LangChain integration with MaximLangchainTracer
-
-Comprehensive tracing support for LangChain and LangGraph applications
-Automatic detection of 8+ LLM providers (OpenAI, Anthropic, Google, Bedrock, etc.)
-Support for chains, agents, retrievers, and tool calls
-Custom metadata and tagging capabilities
-Added @langchain/core as optional dependency
-feat: Enhanced prompt and prompt chain execution capabilities
-
-NEW METHOD: Prompt.run(input, options?) - Execute prompts directly from Prompt objects
-NEW METHOD: PromptChain.run(input, options?) - Execute prompt chains directly from PromptChain objects
-Support for image URLs when running prompts via ImageUrl type
-Support for variables in prompt execution
-feat: New types and interfaces for improved type safety
-
-NEW TYPE: PromptResponse - Standardized response format for prompt executions
-NEW TYPE: AgentResponse - Standardized response format for prompt chain executions
-ENHANCED TYPE: ChatCompletionMessage - More specific interface for assistant messages with tool call support
-ENHANCED TYPE: CompletionRequest - More specific interface with type-safe roles
-NEW TYPE: Choice, Usage - Supporting types for response data with token usage
-NEW TYPE: ImageUrl - Type for image URL content in prompts (extracted from CompletionRequestImageUrlContent)
-NEW TYPE: AgentCost, AgentUsage, AgentResponseMeta - Supporting types for agent responses
-feat: Test run improvements with prompt chain support
-
-Enhanced test run execution with cost and usage tracking for prompt chains
-Support for prompt chains alongside existing prompt and workflow support
-NEW METHOD: TestRunBuilder.withPromptChainVersionId(id, contextToEvaluate?) - Add prompt chain to test runs
-feat: Enhanced exports for better developer experience
-
-NEW EXPORT: MaximLangchainTracer - Main LangChain integration class
-NEW EXPORTS: ChatCompletionMessage, Choice, CompletionRequest, PromptResponse - Core types now available for external use
-Enhanced type safety and IntelliSense support for prompt handling
-feat: Standalone package configuration
-
-MIGRATION: Moved from NX monorepo to standalone package (internal change, no user action needed)
-Added comprehensive build, test, and lint scripts
-Updated TypeScript configuration for ES2022 target
-Added Prettier and ESLint configuration files
-NEW EXPORT: VariableType from dataset models
-deps: LangChain ecosystem support (all optional)
-
-NEW OPTIONAL: @langchain/core as optional dependency (^0.3.0) - only needed if using MaximLangchainTracer
-Migration Guide for v6.5.0:
-
-If you access Prompt.messages directly: Update your type annotations to use CompletionRequest | ChatCompletionMessage types
-If you create custom prompt objects: Ensure your messages array uses the new interface structure
-If you use Generation.addMessages(): The method now accepts (CompletionRequest | ChatCompletionMessage)[] - your existing code will work unchanged
-If you use MaximLogger.generationAddMessage(): The method now accepts (CompletionRequest | ChatCompletionMessage)[] - your existing code will work unchanged
-If you create GenerationConfig objects: The messages field now accepts (CompletionRequest | ChatCompletionMessage)[] - your existing code will work unchanged
-To use LangChain integration: Install @langchain/core and import MaximLangchainTracer
-No action needed for: Regular SDK usage through maxim.logger(), test runs, or prompt management APIs
-⚠️ Note: While these are technically breaking changes at the type level, most existing code will continue to work because CompletionRequest[] is compatible with (CompletionRequest | ChatCompletionMessage)[]. You may only see TypeScript compilation errors if you have strict type checking enabled.
-
-## v6.4.0
-
-- feat: adds provider field to the Prompt type. This field specifies the LLM provider (e.g., 'openai', 'anthropic', etc.) for the prompt.
-- feat: include Langchain integration in the main repository
-
-## v6.3.0
-
-- feat: adds attachments support to Trace, Span, and Generation for file uploads.
-- 3 attachment types are supported: file path, buffer data, and URL has auto-detection of MIME types, file sizes, and names for attachments wherever possible
-- fix: refactored message handling for Generations to prevent keeping messages reference but rather duplicates the object to ensure point in time capture.
-- fix: ensures proper cleanup of resources
-
-```js
-Adding attachments
-
 // Add file as attachment
 entity.addAttachment({
 	id: uuid(),

--- a/index.ts
+++ b/index.ts
@@ -57,7 +57,8 @@ export type {
 	FileAttachment,
 	FileDataAttachment,
 	UrlAttachment,
-} from "./src/lib/logger/components/attachment";
+} from "./src/lib/types";
+export type { MaximAPIDatasetEntriesResponse } from "./src/lib/models/dataset";
 export type { ChatCompletionChoice, Logprobs, TextCompletionChoice, Usage } from "./src/lib/logger/components/generation";
 export { LogWriter } from "./src/lib/logger/writer";
 export type { LogWriterConfig } from "./src/lib/logger/writer";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.9.1",
+	"version": "6.10.0",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",

--- a/src/lib/apis/dataset.ts
+++ b/src/lib/apis/dataset.ts
@@ -1,12 +1,21 @@
+import type { Attachment, UrlAttachment, FileAttachment, FileDataAttachment } from "../types";
 import {
+	VariableType,
 	type DatasetEntry,
 	type DatasetRow,
 	type MaximAPIDatasetResponse,
+	type MaximAPIDatasetEntriesResponse,
 	type MaximAPIDatasetStructureResponse,
 	type MaximAPIDatasetTotalRowsResponse,
+	type SignedURLResponse,
+	type DatasetAttachmentUploadResponse,
+	FileVariablePayload,
+	VariableFileAttachment,
 } from "../models/dataset";
 import { type MaximAPIResponse } from "../models/deployment";
 import { MaximAPI } from "./maxim";
+import mimeTypes from "mime-types";
+import fs from 'fs/promises';
 
 export class MaximDatasetAPI extends MaximAPI {
 	constructor(baseUrl: string, apiKey: string, isDebug?: boolean) {
@@ -14,23 +23,214 @@ export class MaximDatasetAPI extends MaximAPI {
 	}
 
 	public async addDatasetEntries(datasetId: string, datasetEntries: DatasetEntry[]): Promise<void> {
-		return new Promise((resolve, reject) => {
-			this.fetch<MaximAPIResponse>(`/api/sdk/v3/datasets/entries`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ datasetId, entries: datasetEntries }),
-			})
-				.then((response) => {
-					if (response.error) {
-						reject(response.error);
-					} else {
-						resolve();
-					}
-				})
-				.catch((error) => {
-					reject(error);
-				});
+		let nextRowNo = await this.getDatasetTotalRows(datasetId) + 1;
+		const entriesWithFileAttachments: DatasetEntry[] = [];
+		const transformedEntries = datasetEntries.map((entry) => {
+			const rowNo = nextRowNo++;
+			const isFile = entry.cellValue.type === VariableType.FILE;
+			if (isFile) {
+				entriesWithFileAttachments.push({ ...entry, rowNo });
+			}
+			return {
+				rowNo,
+				columnName: entry.columnName,
+				type: entry.cellValue.type,
+				value: isFile ? [] : entry.cellValue.payload,
+			};
 		});
+		const response = await this.fetch<MaximAPIDatasetEntriesResponse>(`/api/sdk/v4/datasets/entries`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ 
+				datasetId, 
+				entries: transformedEntries
+			}),
+		});	
+
+		// Handle the response
+		if ("error" in response) {
+			throw new Error(response.error.message);
+		}
+
+		const mapEntryIDToEntries : Record<string, DatasetEntry> = {};
+		for (const entry of entriesWithFileAttachments) {
+			for(const cell of response.data.cells) {
+				if(cell.columnName === entry.columnName && cell.rowNo === entry.rowNo) {
+					entry.columnId = cell.columnId;
+					mapEntryIDToEntries[cell.entryId] = entry;
+					break;
+				}
+			}
+		}
+        const filePayloads: FileVariablePayload[] = await Promise.all(
+			Object.entries(mapEntryIDToEntries).map(([entryId, entry]) =>
+				this.uploadFileAttachments(datasetId, entryId, entry)
+			)
+		);
+
+        // Transform file payloads to the updates shape required by the API schema
+        const transformedUpdates = filePayloads.map((payload) => ({
+            entryId: payload.entryId,
+            columnName: mapEntryIDToEntries[payload.entryId].columnName,
+            value: {
+                type: "file" as const,
+                payload: payload,
+            },
+        }));
+
+		if(transformedUpdates.length > 0) {
+        try {
+            await this.updateDatasetEntries(datasetId, transformedUpdates);
+			} catch (error) {
+				throw new Error(`Failed to update dataset entries: ${error}`);
+			}
+        }
+	}
+
+	public async uploadFileAttachments(datasetId: string, entryId: string, entry: DatasetEntry): Promise<FileVariablePayload> {
+		const fileAttachments : VariableFileAttachment[] = [];
+		for(const file of entry.cellValue.payload as Attachment[]) {
+			let file_attachment: VariableFileAttachment;
+			let {fileData, mimeType, size} = await this.processAttachment(file);
+
+			if (!mimeType || mimeType === 'application/octet-stream') {
+				const source = file.name ?? (file.type === "file" ? (file as FileAttachment).path : undefined);
+				if (source) {
+					const inferredType = mimeTypes.lookup(source);
+					if (inferredType) {
+						mimeType = inferredType;
+					}
+				}
+			}
+
+			if(file.type !== "url") {
+				const signedURLResponse = await this.getUploadUrlForDatasetAttachment(datasetId, entryId, entry.columnId!, file.id, mimeType, size);
+				try {
+					await this.uploadToSignedUrl(signedURLResponse.url, fileData as Buffer, mimeType, {
+						filename: file.name,
+						entryId: entryId
+					});
+				} catch (error) {
+					throw new Error(`Failed to upload file ${file.name} to signed URL: ${error}`);
+				}
+				file_attachment = {
+					id: file.id,
+					url: signedURLResponse.url,
+					hosted: true,
+					prefix: signedURLResponse.key,
+					props: { 
+						"size": size,
+						"type": mimeType
+					} 
+				}
+			} else {
+
+				file_attachment = {
+					id: file.id,
+					url: file.url,
+					hosted: false,
+					prefix: "",
+					props: { 
+						"size": size,
+						"type": mimeType
+					}
+				}
+			}
+			fileAttachments.push(file_attachment);
+		}	
+		const filePayload : FileVariablePayload = {
+			files: fileAttachments,
+			entryId: entryId
+		}
+		return filePayload;
+	}
+	private async processAttachment(attachment: Attachment): Promise<{fileData: Buffer | null, mimeType: string, size: number}> {
+		if (attachment.type === "url") {
+			return this.processUrlAttachment(attachment as UrlAttachment);
+		} else if (attachment.type === "fileData" || attachment.type === "file") {
+			return this.processFileAttachment(attachment as FileDataAttachment | FileAttachment);
+		} else {
+			throw new Error(`Invalid attachment type: ${(attachment as any).type}. Expected url, fileData, or file.`);
+		}
+	}
+
+	private async processUrlAttachment(attachment: UrlAttachment): Promise<{fileData: null, mimeType: string, size: number}> {
+		try {
+			// Validate URL
+			if (!attachment.url || (!attachment.url.startsWith('http://') && !attachment.url.startsWith('https://'))) {
+				throw new Error(`Invalid URL: ${attachment.url}`);
+			}
+
+			// Get file info from HEAD request
+			const headResponse = await fetch(attachment.url, { method: 'HEAD' });
+			
+			if (!headResponse.ok) {
+				throw new Error(`HTTP ${headResponse.status}: ${headResponse.statusText}`);
+			}
+
+			const mimeType = headResponse.headers.get('content-type') || 'application/octet-stream';
+			const contentLength = headResponse.headers.get('content-length');
+			
+			// Calculate size
+			const size = contentLength ? parseInt(contentLength, 10) : 0;
+			
+			return { fileData: null, mimeType, size };
+			
+		} catch (error) {
+			if (error instanceof Error && error.message.includes('Invalid URL')) {
+				throw error;
+			}
+			throw new Error(`Failed to download URL attachment ${attachment.url}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	private async processFileAttachment(attachment: FileDataAttachment | FileAttachment): Promise<{fileData: Buffer, mimeType: string, size: number}> {
+		try {
+			let fileData: Buffer;
+			let mimeType: string;
+			let size: number;
+			const maxFileSizeBytes = 1024 * 1024 * 100; // 100MB
+
+
+			if (attachment.type === "fileData") {
+				fileData = attachment.data;
+				mimeType = attachment.mimeType || 'application/octet-stream';
+				size = fileData.length;
+				if (size > maxFileSizeBytes) {
+					throw new Error(`File size exceeds the maximum allowed size of ${maxFileSizeBytes} bytes`);
+				  }
+			} else {
+				let stats;
+				try {
+					stats = await fs.stat(attachment.path);
+				} catch (error) {
+					throw new Error(`File not found: ${attachment.path}`);
+				}
+				if (stats.size > maxFileSizeBytes) {
+					throw new Error(`File size exceeds the maximum allowed size of ${maxFileSizeBytes} bytes`);
+				}
+				try {
+					fileData = await fs.readFile(attachment.path);
+				} catch (error) {
+					throw new Error(`File not found: ${attachment.path}`);
+				}
+				
+				mimeType = attachment.mimeType || 'application/octet-stream';
+				size = fileData.length;
+			}
+
+			return { fileData, mimeType, size };
+			
+		} catch (error) {
+			if (error instanceof Error && (
+				error.message.includes('File size exceeds the maximum allowed size') || 
+				error.message.includes('File not found')
+			)) {
+				throw error;
+			}
+			const attachmentName = attachment.name || 'unknown';
+			throw new Error(`Failed to process file attachment ${attachmentName}: ${error instanceof Error ? error.message : String(error)}`);
+		}
 	}
 
 	public async getDatasetTotalRows(datasetId: string): Promise<number> {
@@ -79,5 +279,156 @@ export class MaximDatasetAPI extends MaximAPI {
 					reject(error);
 				});
 		});
+	}
+
+	private async getUploadUrlForDatasetAttachment(
+		datasetId: string, 
+		entryId: string, 
+		columnId: string,
+		key: string, 
+		mimeType: string, 
+		size: number
+	): Promise<SignedURLResponse> {
+		try {
+			const response = await this.fetch<DatasetAttachmentUploadResponse>("/api/sdk/v4/datasets/entries/attachments/", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					datasetId: datasetId,
+					entryId: entryId,
+					columnId: columnId,
+					file: {
+						id: key,
+						type: mimeType,
+						size: size,
+					}
+				}),
+			});
+
+			if (this.isDebug) {
+				console.log("Upload URL Response: ", response);
+			}
+
+			// Handle the response
+			if ("error" in response) {
+				throw new Error(response.error.message);
+			}
+
+			return {
+				url: response.data.url,
+				key: response.data.key
+			};
+
+		} catch (error) {
+			// Handle axios errors with response data
+			if (error && typeof error === 'object' && 'response' in error) {
+				const axiosError = error as any;
+				if (axiosError.response?.data) {
+					const errorData = axiosError.response.data;
+					if (errorData && 
+						typeof errorData === 'object' && 
+						'error' in errorData &&
+						typeof errorData.error === 'object' &&
+						'message' in errorData.error) {
+						throw new Error(errorData.error.message);
+					}
+				}
+			}
+			
+			// Re-throw the error if it's already an Error instance
+			if (error instanceof Error) {
+				throw error;
+			}
+			
+			// For any other type of error, convert to Error
+			throw new Error(String(error));
+		}
+	}
+	public async uploadToSignedUrl(url: string, data: Buffer, mimeType: string, fileContext?: { filename?: string; entryId?: string }): Promise<void> {
+		try {
+			const response = await this.axiosInstance.put(url, data, {
+				headers: {
+					"Content-Type": mimeType,
+					"Content-Length": data.length.toString(),
+				},
+				responseType: "text",
+				timeout: 120000, 
+				transformRequest: [(data: Buffer) => data],
+				transformResponse: [(data: unknown) => data],
+				baseURL: "",
+			});
+
+			if (response.status >= 200 && response.status < 300) {
+				return;
+			}
+
+			if (response.data && typeof response.data === "object" && "error" in response.data) {
+				throw response.data.error;
+			}
+			throw response.data;
+		} catch (error) {
+			// Wrap network/DNS errors with file context for better debugging
+			const context = fileContext ? 
+				` (file: ${fileContext.filename || 'unknown'}, entryId: ${fileContext.entryId || 'unknown'})` : '';
+			
+			if (error instanceof Error) {
+				throw new Error(`Failed to upload file to signed URL${context}: ${error.message}`);
+			}
+			
+			throw new Error(`Failed to upload file to signed URL${context}: ${String(error)}`);
+		}
+	}
+
+    public async updateDatasetEntries(
+        datasetId: string,
+        updates: Array<{
+            entryId: string;
+            columnName: string;
+            value: { type: "file"; payload: FileVariablePayload };
+        }>,
+    ): Promise<void> {
+		try {
+			const response = await this.fetch<MaximAPIResponse>("/api/sdk/v4/datasets/entries", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					datasetId: datasetId,
+					updates: updates
+				}),
+			});
+
+					if (this.isDebug) {
+			console.log("Update dataset entries: ", response);
+		}
+
+		// Handle the response
+		if (response.error) {
+			throw new Error(response.error.message);
+		}
+
+		} catch (error) {
+			// Handle axios errors with response data
+			if (error && typeof error === 'object' && 'response' in error) {
+				const axiosError = error as any;
+				if (axiosError.response?.data) {
+					const errorData = axiosError.response.data;
+					if (errorData && 
+						typeof errorData === 'object' && 
+						'error' in errorData &&
+						typeof errorData.error === 'object' &&
+						'message' in errorData.error) {
+						throw new Error(errorData.error.message);
+					}
+				}
+			}
+			
+			// Re-throw the error if it's already an Error instance
+			if (error instanceof Error) {
+				throw new Error(`Failed to update dataset entries with attachments: ${error.message}`);
+			}
+			
+			// For any other type of error, convert to Error
+			throw new Error(`Failed to update dataset entries with attachments: ${String(error)}`);
+		}
 	}
 }

--- a/src/lib/dataset.test.ts
+++ b/src/lib/dataset.test.ts
@@ -1,0 +1,320 @@
+import "dotenv/config";
+import fs from "node:fs";
+import path from "node:path";
+import { Maxim, VariableType } from "../../index";
+import { MaximDatasetAPI } from "./apis/dataset";
+import type { DatasetEntry } from "./models/dataset";
+import type { FileAttachment, FileDataAttachment, UrlAttachment } from "./types";
+
+// Gate external integration tests behind environment flag
+const RUN_E2E = process.env['MAXIM_E2E'] === "1";
+
+// Load configuration only when running E2E to avoid CI failures
+let baseUrl = "";
+let apiKey = "";
+let testDatasetId = "test-dataset-id";
+if (RUN_E2E) {
+  const config = JSON.parse(fs.readFileSync(`${process.cwd()}/testConfig.json`, "utf-8"));
+  const env = "dev"; // Change this to your test environment
+  if (!config[env]?.apiKey) throw new Error("Missing apiKey in testConfig.json");
+  if (!config[env]?.baseUrl) throw new Error("Missing baseUrl in testConfig.json");
+  baseUrl = config[env].baseUrl;
+  apiKey = config[env].apiKey;
+  testDatasetId = config[env].datasetId || testDatasetId;
+}
+
+let datasetAPI: MaximDatasetAPI;
+
+// Test data setup
+const testDir = path.join(__dirname, "test-data");
+const testImagePath = path.join(testDir, "test-image.png");
+const testTextPath = path.join(testDir, "test-document.txt");
+const testJsonPath = path.join(testDir, "test-data.json");
+
+if (RUN_E2E) beforeAll(async () => {
+	datasetAPI = new MaximDatasetAPI(baseUrl, apiKey, true); // Enable debug mode
+
+	// Create test directory if it doesn't exist
+	if (!fs.existsSync(testDir)) {
+		fs.mkdirSync(testDir, { recursive: true });
+	}
+
+	// Create test files if they don't exist
+	await createTestFiles();
+});
+
+if (RUN_E2E) afterAll(async () => {
+	// Clean up test files
+	if (fs.existsSync(testDir)) {
+		fs.rmSync(testDir, { recursive: true, force: true });
+	}
+});
+
+async function createTestFiles(): Promise<void> {
+	// Create a test image (1x1 pixel PNG)
+	const pngBuffer = Buffer.from([
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+		0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00,
+		0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0x99, 0x01, 0x01, 0x00, 0x00, 0x00,
+		0xff, 0xff, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33,
+		0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82
+	]);
+	fs.writeFileSync(testImagePath, pngBuffer);
+
+	// Create a test text file
+	const textContent = "This is a test document for dataset file attachment testing.\nIt contains multiple lines of text to test file processing.";
+	fs.writeFileSync(testTextPath, textContent, "utf-8");
+
+	// Create a test JSON file
+	const jsonContent = {
+		testData: true,
+		timestamp: new Date().toISOString(),
+		metadata: {
+			purpose: "dataset testing",
+			fileType: "json",
+			size: "small"
+		},
+		items: ["item1", "item2", "item3"]
+	};
+	fs.writeFileSync(testJsonPath, JSON.stringify(jsonContent, null, 2), "utf-8");
+}
+
+function createFileAttachment(filePath: string, name: string, mimeType?: string): FileAttachment {
+	return {
+		id: `file-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+		type: "file",
+		path: filePath,
+		name: name,
+		mimeType: mimeType,
+		tags: { test: "true" },
+		metadata: { source: "test-suite" }
+	};
+}
+
+function createFileDataAttachment(data: Buffer, name: string, mimeType?: string): FileDataAttachment {
+	return {
+		id: `filedata-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+		type: "fileData",
+		data: data,
+		name: name,
+		mimeType: mimeType,
+		tags: { test: "true" },
+		metadata: { source: "test-suite" }
+	};
+}
+
+function createUrlAttachment(url: string, name: string, mimeType?: string): UrlAttachment {
+	return {
+		id: `url-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+		type: "url",
+		url: url,
+		name: name,
+		mimeType: mimeType,
+		tags: { test: "true" },
+		metadata: { source: "test-suite" }
+	};
+}
+
+(RUN_E2E ? describe : describe.skip)("MaximDatasetAPI - addDatasetEntries Integration Tests", () => {
+	test("should add dataset entries with file attachments", async () => {
+		const fileAttachment = createFileAttachment(testImagePath, "test-image.png", "image/png");
+		
+		const timestamp = Date.now();
+		const uniqueId = `file-attachment-test-${timestamp}-${Math.random().toString(36).slice(2, 11)}`;
+		
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: `test_file_attachment_${timestamp}_${uniqueId}`,
+				cellValue: {
+					type: VariableType.FILE,
+					payload: [fileAttachment]
+				}
+			}
+		];
+
+		await datasetAPI.addDatasetEntries(testDatasetId, datasetEntries);
+	}, 30000); // 30 second timeout for file upload
+
+	test("should add dataset entries with fileData attachments", async () => {
+		const textContent = fs.readFileSync(testTextPath);
+		const fileDataAttachment = createFileDataAttachment(textContent, "test-document.txt", "text/plain");
+		
+		const timestamp = Date.now();
+		const uniqueId = `filedata-attachment-test-${timestamp}-${Math.random().toString(36).slice(2, 11)}`;
+		
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: `test_filedata_attachment_${timestamp}_${uniqueId}`,
+				cellValue: {
+					type: VariableType.FILE,
+					payload: [fileDataAttachment]
+				}
+			}
+		];
+
+		await datasetAPI.addDatasetEntries(testDatasetId, datasetEntries);
+	}, 30000);
+
+	test("should add dataset entries with URL attachments", async () => {
+		// Using a publicly accessible test image URL
+		const urlAttachment = createUrlAttachment(
+			"https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png", 
+			"test-url-image.png", 
+			"image/png"
+		);
+		
+		const timestamp = Date.now();
+		const uniqueId = `url-attachment-test-${timestamp}-${Math.random().toString(36).slice(2, 11)}`;
+		
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: `test_url_attachment_${timestamp}_${uniqueId}`,
+				cellValue: {
+					type: VariableType.FILE,
+					payload: [urlAttachment]
+				}
+			}
+		];
+
+		await datasetAPI.addDatasetEntries(testDatasetId, datasetEntries);
+	}, 30000);
+
+	test("should add dataset entries with multiple file types", async () => {
+		const fileAttachment = createFileAttachment(testJsonPath, "test-data.json", "application/json");
+		const jsonContent = fs.readFileSync(testJsonPath);
+		const fileDataAttachment = createFileDataAttachment(jsonContent, "test-data-copy.json", "application/json");
+		const urlAttachment = createUrlAttachment(
+			"https://httpbin.org/json", 
+			"remote-json.json", 
+			"application/json"
+		);
+		
+		const timestamp = Date.now();
+		const uniqueId = `multiple-files-test-${timestamp}-${Math.random().toString(36).slice(2, 11)}`;
+		
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: `test_multiple_files_${timestamp}_${uniqueId}`,
+				cellValue: {
+					type: VariableType.FILE,
+					payload: [fileAttachment, fileDataAttachment, urlAttachment]
+				}
+			}
+		];
+
+		await datasetAPI.addDatasetEntries(testDatasetId, datasetEntries);
+	}, 45000); // Longer timeout for multiple files
+
+	test("should handle large file size validation", async () => {
+		// Create a large buffer (over 100MB limit)
+		const largeBuffer = Buffer.alloc(101 * 1024 * 1024, 'a'); // 101MB
+		const largeFileAttachment = createFileDataAttachment(largeBuffer, "large-file.txt", "text/plain");
+		
+		const timestamp = Date.now();
+		const uniqueId = `large-file-test-${timestamp}-${Math.random().toString(36).slice(2, 11)}`;
+		
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: `test_large_file_${timestamp}_${uniqueId}`,
+				cellValue: {
+					type: VariableType.FILE,
+					payload: [largeFileAttachment]
+				}
+			}
+		];
+
+		await expect(datasetAPI.addDatasetEntries(testDatasetId, datasetEntries))
+			.rejects.toThrow(/File size exceeds the maximum allowed size/);
+	});
+
+	test("should infer MIME types from file extensions", async () => {
+		// Test with file that has no explicit MIME type
+		const fileAttachment = createFileAttachment(testImagePath, "test-without-mimetype.png");		
+		const timestamp = Date.now();
+		const uniqueId = `mime-inference-test-${timestamp}-${Math.random().toString(36).slice(2, 11)}`;
+		
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: `test_mime_inference_${timestamp}_${uniqueId}`,
+				cellValue: {
+					type: VariableType.FILE,
+					payload: [fileAttachment]
+				}
+			}
+		];
+
+		await datasetAPI.addDatasetEntries(testDatasetId, datasetEntries);
+	}, 30000);
+
+	test("should handle invalid URL attachments gracefully", async () => {
+		const timestamp = Date.now();
+		const uniqueId = `invalid-url-test-${timestamp}-${Math.random().toString(36).slice(2, 11)}`;
+		const invalidUrlAttachment = createUrlAttachment("invalid-url", `${uniqueId}.txt`, "text/plain");
+		
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: `test_invalid_url_${timestamp}_${uniqueId}`,
+				cellValue: {
+					type: VariableType.FILE,
+					payload: [invalidUrlAttachment]
+				}
+			}
+		];
+
+		await expect(datasetAPI.addDatasetEntries(testDatasetId, datasetEntries))
+			.rejects.toThrow(/Invalid URL/);
+	});
+
+	test("should handle non-existent file attachments gracefully", async () => {
+		const nonExistentFileAttachment = createFileAttachment("/path/to/nonexistent/file.txt", "missing.txt", "text/plain");
+		
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: "context",
+				cellValue: {
+					type: VariableType.FILE,
+					payload: [nonExistentFileAttachment]
+				}
+			}
+		];
+
+		await expect(datasetAPI.addDatasetEntries(testDatasetId, datasetEntries))
+			.rejects.toThrow(/File not found/);
+	});
+
+	test("should add text and JSON dataset entries", async () => {
+		const datasetEntries: DatasetEntry[] = [
+			{
+				columnName: "Input",
+				cellValue: {
+					type: VariableType.TEXT,
+					payload: "This is a test text entry"
+				}
+			},
+			{
+				columnName: "expected_output",
+				cellValue: {
+					type: VariableType.JSON,
+					payload: JSON.stringify({ test: true, value: 42, array: [1, 2, 3] })
+				}
+			}
+		];
+
+		await datasetAPI.addDatasetEntries(testDatasetId, datasetEntries);
+	});
+});
+
+(RUN_E2E ? describe : describe.skip)("MaximDatasetAPI - Helper Methods Tests", () => {
+	test("should get dataset total rows", async () => {
+		const totalRows = await datasetAPI.getDatasetTotalRows(testDatasetId);
+		expect(typeof totalRows).toBe("number");
+		expect(totalRows).toBeGreaterThanOrEqual(0);
+	});
+
+	test("should get dataset structure", async () => {
+		const structure = await datasetAPI.getDatasetDatastructure(testDatasetId);
+		expect(typeof structure).toBe("object");
+		expect(structure).not.toBeNull();
+	});
+});

--- a/src/lib/logger/components/attachment.ts
+++ b/src/lib/logger/components/attachment.ts
@@ -2,68 +2,7 @@ import * as fs from "fs";
 import * as mimeTypes from "mime-types";
 import * as path from "path";
 import { uniqueId } from "../utils";
-
-/**
- * Base properties shared by all attachment types in the Maxim logging system.
- */
-export type BaseAttachmentProps = {
-	id: string;
-	name?: string;
-	mimeType?: string;
-	size?: number;
-	tags?: Record<string, string>;
-	metadata?: Record<string, string>;
-};
-
-/**
- * File attachment type for referencing files on the local filesystem.
- */
-export type FileAttachment = BaseAttachmentProps & {
-	type: "file";
-	path: string;
-};
-
-/**
- * File attachment with storage key for internal processing.
- */
-export type FileAttachmentWithKey = FileAttachment & { key: string };
-
-/**
- * File data attachment type for directly embedding binary data.
- */
-export type FileDataAttachment = BaseAttachmentProps & {
-	type: "fileData";
-	data: Buffer;
-};
-
-/**
- * File data attachment with storage key for internal processing.
- */
-export type FileDataAttachmentWithKey = FileDataAttachment & { key: string };
-
-/**
- * URL attachment type for referencing external resources.
- */
-export type UrlAttachment = BaseAttachmentProps & {
-	type: "url";
-	url: string;
-};
-
-/**
- * URL attachment with storage key for internal processing.
- */
-export type UrlAttachmentWithKey = UrlAttachment & { key: string };
-
-/**
- * Discriminated union type representing all possible attachment types.
- */
-export type Attachment = FileAttachment | FileDataAttachment | UrlAttachment;
-
-/**
- * Attachment with storage key for internal processing.
- */
-export type AttachmentWithKey = FileAttachmentWithKey | FileDataAttachmentWithKey | UrlAttachmentWithKey;
-
+import type { Attachment } from "../../types";
 /**
  * Auto-populates missing fields in an attachment based on available information.
  *

--- a/src/lib/logger/components/generation.ts
+++ b/src/lib/logger/components/generation.ts
@@ -1,7 +1,7 @@
 import { ChatCompletionMessage, CompletionRequest, CompletionRequestContent } from "../../models/prompt";
 import { uniqueId, utcNow } from "../utils";
 import { LogWriter } from "../writer";
-import { Attachment } from "./attachment";
+import type { Attachment } from "../../types";
 import { EvaluatableBaseContainer } from "./base";
 import { Entity } from "./types";
 

--- a/src/lib/logger/components/span.ts
+++ b/src/lib/logger/components/span.ts
@@ -1,5 +1,5 @@
 import { LogWriter } from "../writer";
-import { Attachment } from "./attachment";
+import type { Attachment } from "../../types";
 import { EventEmittingBaseContainer } from "./base";
 import { Error, ErrorConfig } from "./error";
 import { Generation, GenerationConfig } from "./generation";

--- a/src/lib/logger/components/trace.ts
+++ b/src/lib/logger/components/trace.ts
@@ -1,5 +1,5 @@
 import { LogWriter } from "../writer";
-import { Attachment } from "./attachment";
+import type { Attachment } from "../../types";
 import { EventEmittingBaseContainer } from "./base";
 import { Error, ErrorConfig } from "./error";
 import { Generation, GenerationConfig } from "./generation";

--- a/src/lib/logger/writer.ts
+++ b/src/lib/logger/writer.ts
@@ -8,13 +8,13 @@ import { MaximCache } from "../cache/cache";
 import { Mutex } from "../utils/mutex";
 import { Queue } from "../utils/queue";
 import { generateUniqueId } from "../utils/utils";
-import {
+import type {
 	Attachment,
+	FileDataAttachmentWithKey,
 	AttachmentWithKey,
 	FileAttachmentWithKey,
-	FileDataAttachmentWithKey,
-	populateAttachmentFields,
-} from "./components/attachment";
+} from "../types";
+import { populateAttachmentFields } from "./components/attachment";
 import { CommitLog, Entity } from "./components/types";
 
 export type LogWriterConfig = {

--- a/src/lib/maxim.test.ts
+++ b/src/lib/maxim.test.ts
@@ -157,10 +157,18 @@ test("get prompts from a folder", async () => {
 test.skip("add dataset entries", async () => {
 	await maxim.addDatasetEntries("clo7as7v2001axvt02rbx70qg", [
 		{
-			input: {
+			columnName: "input",
+			cellValue: {
+				type: VariableType.TEXT,
+				payload: ""
+			}
+		},
+		{
+			columnName: "input",
+			cellValue: {
 				type: VariableType.TEXT,
 				payload: "Hello",
-			},
+			}
 		},
 	]);
 });
@@ -169,7 +177,8 @@ test.skip("add dataset entries should throw error on invalid dataset id", async 
 	try {
 		await maxim.addDatasetEntries("clo7as7v2001axvt02rbx70", [
 			{
-				input: {
+				columnName: "input",
+				cellValue: {
 					type: VariableType.TEXT,
 					payload: "Hello",
 				},

--- a/src/lib/maxim.ts
+++ b/src/lib/maxim.ts
@@ -7,7 +7,7 @@ import { MaximCache } from "./cache/cache";
 import { MaximInMemoryCache } from "./cache/inMemory";
 import { IncomingQuery, QueryObject, findAllMatches, findBestMatch, parseIncomingQuery } from "./filterObjects";
 import { LoggerConfig, MaximLogger } from "./logger/logger";
-import { DatasetEntry } from "./models/dataset";
+import type { DatasetEntry } from "./models/dataset";
 import { RuleGroupType } from "./models/deployment";
 import { Folder } from "./models/folder";
 import { ImageUrl, Prompt, PromptVersionsAndRules } from "./models/prompt";
@@ -1121,7 +1121,8 @@ export class Maxim {
 	 * @example
 	 * await maxim.addDatasetEntries("datasetId", [
 	 * 	{
-	 * 		input: {
+	 * 		columnName: "input",
+	 * 		cellValue: {
 	 * 			type: VariableType.TEXT,
 	 * 			payload: "cell value",
 	 * 		},

--- a/src/lib/models/dataset.ts
+++ b/src/lib/models/dataset.ts
@@ -1,4 +1,5 @@
 import type { CSVFile } from "../utils/csvParser";
+import type { Attachment } from "../types";
 
 /**
  * Enumeration of supported variable types for dataset entries.
@@ -32,17 +33,43 @@ export enum VariableType {
 	 * @example '{"name": "John", "age": 30}', '[1, 2, 3]', '{"metadata": {...}}'
 	 */
 	JSON = "json",
+
+	/**
+	 * File data type for file attachments.
+	 * @example "file.pdf", "image.png", "audio.mp3"
+	 */
+	FILE = "file",
 }
 
 export type Variable = {
-	type: VariableType;
+	type: VariableType.TEXT;
 	payload: string;
+} | {
+	type: VariableType.JSON;
+	payload: string;
+} | {
+	type: VariableType.FILE;
+	payload: Attachment[];
+};
+
+export type VariableFileAttachment = {
+	id: string;
+	url: string;
+	hosted: boolean;
+	prefix?: string;
+	props: { [key: string]: number | string | boolean };
+};
+
+export type FileVariablePayload = {
+	files: VariableFileAttachment[];
+	entryId: string;
 };
 
 export type DatasetEntry = {
-	input: Variable;
-	context?: Variable;
-	expectedOutput?: Variable;
+	rowNo?: number;
+	columnName: string;
+	cellValue: Variable;
+	columnId?: string;
 };
 
 export type DatasetRow = Record<string, string | string[]>;
@@ -70,6 +97,24 @@ export type MaximAPIDatasetStructureResponse =
 export type MaximAPIDatasetTotalRowsResponse =
 	| {
 			data: number;
+	  }
+	| {
+			error: {
+				message: string;
+			};
+	  };
+
+export type MaximAPIDatasetEntriesResponse =
+	| {
+			data: {
+				ids: string[];
+				cells: {
+					rowNo: number;
+					entryId: string;
+					columnId: string;
+					columnName: string;
+				}[];
+			};
 	  }
 	| {
 			error: {
@@ -141,3 +186,18 @@ export type DataValue<T extends DataStructure | undefined> = T extends DataStruc
 			| CSVFile<Record<keyof T, number>>
 			| ((page: number) => Promise<Data<T>[] | null | undefined> | Data<T>[] | null | undefined)
 	: string;
+
+export type SignedURLResponse = {
+		url: string;
+		key: string;
+	};
+	
+export type DatasetAttachmentUploadResponse = 
+		| {
+			data: SignedURLResponse;
+		}
+		| {
+			error: {
+				message: string;
+			};
+		};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Base properties shared by all attachment types in the Maxim logging system.
+ */
+export type BaseAttachmentProps = {
+	id: string;
+	name?: string;
+	mimeType?: string;
+	size?: number; // bytes
+	tags?: Record<string, string>;
+	metadata?: Record<string, string>;
+};
+
+/**
+ * File attachment type for referencing files on the local filesystem.
+ */
+export type FileAttachment = BaseAttachmentProps & {
+	type: "file";
+	path: string;
+};
+
+/**
+ * File attachment with storage key for internal processing.
+ */
+export type FileAttachmentWithKey = FileAttachment & { key: string };
+
+/**
+ * File data attachment type for directly embedding binary data.
+ */
+export type FileDataAttachment = BaseAttachmentProps & {
+	type: "fileData";
+	data: Buffer;
+};
+
+/**
+ * File data attachment with storage key for internal processing.
+ */
+export type FileDataAttachmentWithKey = FileDataAttachment & { key: string };
+
+/**
+ * URL attachment type for referencing external resources.
+ */
+export type UrlAttachment = BaseAttachmentProps & {
+	type: "url";
+	url: string;
+};
+
+/**
+ * URL attachment with storage key for internal processing.
+ */
+export type UrlAttachmentWithKey = UrlAttachment & { key: string };
+
+/**
+ * Discriminated union type representing all possible attachment types.
+ */
+export type Attachment = FileAttachment | FileDataAttachment | UrlAttachment;
+
+/**
+ * Attachment with storage key for internal processing.
+ */
+export type AttachmentWithKey = FileAttachmentWithKey | FileDataAttachmentWithKey | UrlAttachmentWithKey;


### PR DESCRIPTION
### TL;DR

Implemented v4 datasets API with support for file attachments in dataset entries.

### What changed?

- Added support for the new v4 datasets API with a flattened POST structure for dataset entries
- Implemented file attachment support in dataset entries with three types: file path, file data, and URL
- Added signed URL helpers for uploading dataset attachments (`getUploadUrlForDatasetAttachment`, `uploadToSignedUrl`)
- Added comprehensive test suite for dataset file attachment functionality
- Updated dataset models to support the new file attachment types and API structure

### How to test?

1. Create dataset entries with file attachments:
```javascript
const fileAttachment = {
  id: "unique-id",
  type: "file",
  path: "/path/to/file.pdf",
  name: "document.pdf"
};

await maxim.addDatasetEntries("datasetId", [
  {
    columnName: "context",
    cellValue: {
      type: "file",
      payload: [fileAttachment]
    }
  }
]);
```

2. Test with different attachment types (file path, file data buffer, or URL)
3. Verify attachments are properly uploaded and associated with dataset entries
4. Use the already added test file.

### Why make this change?

This change enables users to include file attachments in dataset entries. 