### PR TITLE
[Prompts] fix the usage return type for prompt run

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,10 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 
 ## Version changelog
 
+### v6.9.1
+
+- **fix**: Fixed the usage type for `PromptResponse` and `PromptChainResponse` to respond with camel-case instead of snake-case
+
 ### v6.9.0
 
 - **feat**: Added `deploymentId` support to prompt configurations

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.9.0",
+	"version": "6.9.1",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",

--- a/src/lib/apis/prompt.ts
+++ b/src/lib/apis/prompt.ts
@@ -79,7 +79,16 @@ export class MaximPromptAPI extends MaximAPI {
 					if (response.error) {
 						reject(new Error(response.error.message));
 					} else {
-						resolve(response.data);
+						const responseData = response.data;
+						resolve({
+							...responseData,
+							usage: {
+								promptTokens: responseData.usage.prompt_tokens,
+								completionTokens: responseData.usage.completion_tokens,
+								totalTokens: responseData.usage.total_tokens,
+								latency: responseData.usage.latency,
+							},
+						});
 					}
 				})
 				.catch((error) => {

--- a/src/lib/apis/promptChain.ts
+++ b/src/lib/apis/promptChain.ts
@@ -67,7 +67,18 @@ export class MaximPromptChainAPI extends MaximAPI {
 					if (response.error) {
 						reject(new Error(response.error.message));
 					} else {
-						resolve(response.data);
+						const responseData = response.data;
+						resolve({
+							...response.data,
+							meta: {
+								...response.data.meta,
+								usage: {
+									completionTokens: responseData.meta.usage.completion_tokens,
+									promptTokens: responseData.meta.usage.prompt_tokens,
+									totalTokens: responseData.meta.usage.total_tokens,
+								},
+							},
+						});
 					}
 				})
 				.catch((error) => {

--- a/src/lib/models/prompt.ts
+++ b/src/lib/models/prompt.ts
@@ -282,6 +282,8 @@ export type MaximApiPromptsResponse = {
 };
 
 export type MaximApiPromptRunResponse = {
-	data: PromptResponse;
+	data: Omit<PromptResponse, "usage"> & {
+		usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number; latency: number };
+	};
 	error?: { message: string };
 };

--- a/src/lib/models/promptChain.ts
+++ b/src/lib/models/promptChain.ts
@@ -1,5 +1,5 @@
-import { Prompt } from "./prompt";
 import { DeploymentVersionDeploymentConfig } from "./deployment";
+import { Prompt } from "./prompt";
 
 export type AgentCost = {
 	input: number;
@@ -83,6 +83,10 @@ export type MaximApiPromptChainsResponse = {
 };
 
 export type MaximApiAgentRunResponse = {
-	data: AgentResponse;
+	data: Omit<AgentResponse, "meta"> & {
+		meta: Omit<AgentResponseMeta, "usage"> & {
+			usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+		};
+	};
 	error?: { message: string };
 };


### PR DESCRIPTION
# Standardize token usage field names in API responses

This PR updates the API response handling for both `MaximPromptAPI` and `MaximPromptChainAPI` to standardize the token usage field names. The changes convert snake_case field names from the API responses (like `prompt_tokens`) to camelCase (like `promptTokens`) in the client-side response objects.

The modifications ensure consistent naming conventions throughout the codebase by:

1. Transforming token usage fields in prompt API responses
2. Transforming token usage fields in prompt chain API responses
3. Updating type definitions to properly reflect the API response structure before transformation

This change maintains backward compatibility while providing a more consistent interface for consumers of these APIs.
