### PR TITLE
[Logs] adds ability to add custom metrics to components

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,15 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 
 ## Version changelog
 
+### v6.14.0
+
+- **New Feature**: Added comprehensive metric tracking capabilities across all logger components
+  - Added `addMetric()` method to `Generation` class for tracking generation quality metrics, token accounting, and streaming characteristics
+  - Added `addMetric()` method to `Retrieval` class for tracking RAG evaluation metrics like precision, recall, MRR, and NDCG
+  - Added `addMetric()` method to `Session` class for tracking session-level aggregates like trace counts and message counts
+  - Added `addMetric()` method to `Trace` class for tracking trace-level metrics like tool call counts, costs, and evaluation scores
+  - Added logger level methods to `MaximLogger` class: `sessionAddMetric()`, `traceAddMetric()`, `generationAddMetric()`, and `retrievalAddMetric()`
+
 ### v6.13.0
 
 - **feat**: Added `AI SDK v5` support. Keeps `AI SDK v4` support intact

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.13.0",
+	"version": "6.14.0",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",

--- a/src/lib/evaluators/evaluators.ts
+++ b/src/lib/evaluators/evaluators.ts
@@ -131,7 +131,7 @@ export function createCustomEvaluator<T extends DataStructure | undefined = unde
  *   .withEvaluators(qualityEvaluator)
  *   .run();
  */
-export function createCustomCombinedEvaluatorsFor<const U extends string[]>(...names: U) {
+export function createCustomCombinedEvaluatorsFor<U extends readonly [string, ...string[]]>(...names: U) {
 	return {
 		/**
 		 * Builds the combined evaluator with evaluation function and pass/fail criteria.

--- a/src/lib/logger/components/generation.ts
+++ b/src/lib/logger/components/generation.ts
@@ -334,6 +334,44 @@ export class Generation extends EvaluatableBaseContainer {
 	}
 
 	/**
+	 * Adds a numeric metric to this generation.
+	 *
+	 * Records quantitative values such as generation quality metrics, token accounting,
+	 * and streaming/throughput characteristics under a named metric. Each call adds
+	 * or updates a single metric entry.
+	 *
+	 * Common examples include: `tokens_in`, `tokens_out`, `output_tokens`, `ttft_ms` (Time To First Token),
+	 * `tps` (tokens per second), `avg_logprob`.
+	 *
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 * @example
+	 * generation.addMetric('tokens_in', 312);
+	 * generation.addMetric('tokens_out', 87);
+	 * generation.addMetric('output_tokens', 87);
+	 * generation.addMetric('ttft_ms', 180.5);
+	 * generation.addMetric('tps', 15.8);
+	 * generation.addMetric('avg_logprob', -0.32);
+	 */
+	public addMetric(name: string, value: number) {
+		this.commit("update", { metrics: { [name]: value } });
+	}
+
+	/**
+	 * Static method to add a metric to any generation by ID.
+	 *
+	 * @param writer - The log writer instance
+	 * @param id - The generation ID
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (float/number)
+	 * @returns void
+	 */
+	public static addMetric_(writer: LogWriter, id: string, name: string, value: number) {
+		EvaluatableBaseContainer.commit_(writer, Entity.GENERATION, id, "update", { metrics: { [name]: value } });
+	}
+
+	/**
 	 * Adds an attachment to this generation (can be of type `file`, `data`, or `url`).
 	 *
 	 * @param attachment - The attachment to add (file, data, or URL)

--- a/src/lib/logger/components/retrieval.ts
+++ b/src/lib/logger/components/retrieval.ts
@@ -117,4 +117,40 @@ export class Retrieval extends EvaluatableBaseContainer {
 		}
 		EvaluatableBaseContainer.commit_(writer, Entity.RETRIEVAL, id, "end", { docs: finalDocs, endTimestamp: new Date() });
 	}
+
+	/**
+	 * Adds a numeric metric to this retrieval.
+	 *
+	 * Records quantitative values used in information retrieval and RAG evaluation under a
+	 * named metric. Each call adds or updates a single metric entry.
+	 *
+	 * Common examples include: `precision`, `recall`, `f1_score`, `mrr` (Mean Reciprocal Rank),
+	 * `ndcg` (Normalized Discounted Cumulative Gain), `avg_similarity`, `results_count`,
+	 * `unique_sources_count`.
+	 *
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 * @example
+	 * retrieval.addMetric('precision', 0.82);
+	 * retrieval.addMetric('recall', 0.76);
+	 * retrieval.addMetric('mrr', 0.61);
+	 * retrieval.addMetric('results_count', 10);
+	 */
+	public addMetric(name: string, value: number) {
+		this.commit("update", { metrics: { [name]: value } });
+	}
+
+	/**
+	 * Static method to add a metric to any retrieval by ID.
+	 *
+	 * @param writer - The log writer instance
+	 * @param id - The retrieval ID
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (float/number)
+	 * @returns void
+	 */
+	public static addMetric_(writer: LogWriter, id: string, name: string, value: number) {
+		EvaluatableBaseContainer.commit_(writer, Entity.RETRIEVAL, id, "update", { metrics: { [name]: value } });
+	}
 }

--- a/src/lib/logger/components/session.ts
+++ b/src/lib/logger/components/session.ts
@@ -130,4 +130,36 @@ export class Session extends EvaluatableBaseContainer {
 		config.sessionId = id;
 		return new Trace(config, writer);
 	}
+
+	/**
+	 * Adds a numeric metric to this session.
+	 *
+	 * Records quantitative values such as counts and aggregates across all traces in the
+	 * session. Each call adds or updates a single metric entry under the provided name.
+	 *
+	 * Common examples include: `tool_calls_count`, `traces_count`, `user_messages_count`, `assistant_messages_count`.
+	 *
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 * @example
+	 * session.addMetric('traces_count', 4);
+	 * session.addMetric('user_messages_count', 2);
+	 */
+	public addMetric(name: string, value: number) {
+		this.commit("update", { metrics: { [name]: value } });
+	}
+
+	/**
+	 * Static method to add a metric to any session by ID.
+	 *
+	 * @param writer - The log writer instance
+	 * @param id - The session ID
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 */
+	public static addMetric_(writer: LogWriter, id: string, name: string, value: number) {
+		EvaluatableBaseContainer.commit_(writer, Session.ENTITY, id, "update", { metrics: { [name]: value } });
+	}
 }

--- a/src/lib/logger/components/trace.ts
+++ b/src/lib/logger/components/trace.ts
@@ -184,6 +184,42 @@ export class Trace extends EventEmittingBaseContainer {
 	}
 
 	/**
+	 * Adds a numeric metric to this trace.
+	 *
+	 * Records quantitative values such as tool call counts, retry attempts, total tokens,
+	 * overall cost, or aggregated evaluation scores under a named metric. Each call adds
+	 * or updates a single metric entry.
+	 *
+	 * Common examples include: `tool_calls_count`, `retries_count`, `cost_usd`, `tokens_total`,
+	 * `eval_overall_score`, `user_feedback_score`.
+	 *
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 * @example
+	 * trace.addMetric('tool_calls_count', 3);
+	 * trace.addMetric('cost_usd', 0.05);
+	 * trace.addMetric('tokens_total', 1420);
+	 * trace.addMetric('user_feedback_score', 4.7);
+	 */
+	public addMetric(name: string, value: number) {
+		this.commit("update", { metrics: { [name]: value } });
+	}
+
+	/**
+	 * Static method to add a metric to any trace by ID.
+	 *
+	 * @param writer - The log writer instance
+	 * @param id - The trace ID
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (float/number)
+	 * @returns void
+	 */
+	public static addMetric_(writer: LogWriter, id: string, name: string, value: number) {
+		EventEmittingBaseContainer.commit_(writer, Entity.TRACE, id, "update", { metrics: { [name]: value } });
+	}
+
+	/**
 	 * Adds an attachment to this trace.
 	 *
 	 * @param attachment - The attachment to add (can be of type file, data, or URL)

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -213,6 +213,25 @@ export class MaximLogger {
 	}
 
 	/**
+	 * Adds a numeric metric to a session.
+	 *
+	 * Records quantitative values such as counts and aggregates across all traces in the
+	 * session under a named metric.
+	 *
+	 * Common examples include: `tool_calls_count`, `traces_count`, `user_messages_count`, `assistant_messages_count`.
+	 *
+	 * @param sessionId - The unique identifier of the session
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 * @example
+	 * logger.sessionAddMetric('session-123', 'traces_count', 4);
+	 */
+	public sessionAddMetric(sessionId: string, name: string, value: number) {
+		Session.addMetric_(this.writer, sessionId, name, value);
+	}
+
+	/**
 	 * Creates a new trace associated with a session.
 	 *
 	 * @param sessionId - The unique identifier of the session
@@ -368,6 +387,27 @@ export class MaximLogger {
 	 */
 	public traceAddToSession(traceId: string, sessionId: string) {
 		Trace.addToSession_(this.writer, traceId, sessionId);
+	}
+
+	/**
+	 * Adds a numeric metric to a trace.
+	 *
+	 * Records quantitative values such as tool call counts, retry attempts, total tokens,
+	 * overall cost, or aggregated evaluation scores under a named metric.
+	 *
+	 * Common examples include: `tool_calls_count`, `retries_count`, `cost_usd`, `tokens_total`,
+	 * `eval_overall_score`, `user_feedback_score`.
+	 *
+	 * @param traceId - The unique identifier of the trace
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 * @example
+	 * logger.traceAddMetric('trace-123', 'tool_calls_count', 5);
+	 * logger.traceAddMetric('trace-123', 'tokens_total', 1500);
+	 */
+	public traceAddMetric(traceId: string, name: string, value: number) {
+		Trace.addMetric_(this.writer, traceId, name, value);
 	}
 
 	/**
@@ -548,6 +588,29 @@ export class MaximLogger {
 	 */
 	public generationSetModelParameters(generationId: string, modelParameters: Record<string, any>) {
 		Generation.setModelParameters_(this.writer, generationId, modelParameters);
+	}
+
+	/**
+	 * Adds a numeric metric to a generation.
+	 *
+	 * Records quantitative values such as generation quality metrics, token accounting,
+	 * and streaming/throughput characteristics under a named metric.
+	 *
+	 * Common examples include: `tokens_in`, `tokens_out`, `output_tokens`, `ttft_ms` (Time To First Token),
+	 * `tps` (tokens per second), `avg_logprob`.
+	 *
+	 * @param generationId - The unique identifier of the generation
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 * @example
+	 * logger.generationAddMetric('gen-123', 'output_tokens', 87);
+	 * logger.generationAddMetric('gen-123', 'ttft_ms', 180.5);
+	 * logger.generationAddMetric('gen-123', 'tps', 15.8);
+	 * logger.generationAddMetric('gen-123', 'avg_logprob', -0.32);
+	 */
+	public generationAddMetric(generationId: string, name: string, value: number) {
+		Generation.addMetric_(this.writer, generationId, name, value);
 	}
 
 	/**
@@ -862,6 +925,28 @@ export class MaximLogger {
 	 */
 	public retrievalInput(retrievalId: string, input: string) {
 		Retrieval.input_(this.writer, retrievalId, input);
+	}
+
+	/**
+	 * Adds a numeric metric to a retrieval.
+	 *
+	 * Records quantitative values used in information retrieval and RAG evaluation under a
+	 * named metric.
+	 *
+	 * Common examples include: `precision`, `recall`, `f1_score`, `mrr` (Mean Reciprocal Rank),
+	 * `ndcg` (Normalized Discounted Cumulative Gain), `avg_similarity`, `results_count`,
+	 * `unique_sources_count`.
+	 *
+	 * @param retrievalId - The unique identifier of the retrieval
+	 * @param name - Name of the metric
+	 * @param value - Numeric value of the metric (numeric)
+	 * @returns void
+	 * @example
+	 * logger.retrievalAddMetric('retrieval-123', 'precision', 0.86);
+	 * logger.retrievalAddMetric('retrieval-123', 'mrr', 0.58);
+	 */
+	public retrievalAddMetric(retrievalId: string, name: string, value: number) {
+		Retrieval.addMetric_(this.writer, retrievalId, name, value);
 	}
 
 	/**

--- a/src/lib/models/evaluator.ts
+++ b/src/lib/models/evaluator.ts
@@ -29,7 +29,7 @@ export type LocalEvaluatorType<T extends DataStructure | undefined = undefined> 
 };
 
 export type CombinedLocalEvaluatorType<T extends DataStructure | undefined, U extends Record<string, PassFailCriteriaType>> = {
-	names: (keyof U)[];
+	names: ReadonlyArray<keyof U>;
 	evaluationFunction: (
 		result: { output: string; contextToEvaluate?: string | string[] },
 		data: Data<T>,


### PR DESCRIPTION
# Add Metrics Support for Logging Components

This PR adds the ability to record numeric metrics across all major logging components: Generation, Retrieval, Session, and Trace. Each component now has:

1. An `addMetric(name, value)` instance method
2. A static `addMetric_(writer, id, name, value)` method
3. Corresponding logger methods like `generationAddMetric`, `retrievalAddMetric`, etc.

The metrics feature allows recording quantitative values specific to each component:

- **Generation**: token counts, generation speed metrics (TTFT, TPS), log probabilities
- **Retrieval**: precision, recall, MRR, NDCG, result counts
- **Session**: message counts, trace counts, tool call aggregates
- **Trace**: tool call counts, token totals, costs, evaluation scores

Each method includes comprehensive JSDoc with examples to guide proper usage.
