### PR TITLE
[Maxim JS] Adds flush for logs after all individual calls in AI SDK wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.29.1",
+	"version": "6.29.2",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",

--- a/src/lib/logger/vercel/v1/wrapper.ts
+++ b/src/lib/logger/vercel/v1/wrapper.ts
@@ -234,6 +234,7 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 					trace.end();
 				}
 			}
+			await this.logger.flush();
 		}
 	}
 
@@ -331,6 +332,9 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 											trace.end();
 										}
 									}
+
+									// Flush logs after processStream and tool-result logging complete
+									await wrapperInstance.logger.flush();
 								} catch (error) {
 									console.error("[MaximSDK] Processing failed:", error);
 									if (generation) {
@@ -339,6 +343,8 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 										});
 										generation.end();
 									}
+									// Flush logs even on error
+									await wrapperInstance.logger.flush();
 								}
 
 								// Now close the stream
@@ -364,6 +370,8 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 							});
 							generation.end();
 						}
+						// Flush logs on stream error
+						await wrapperInstance.logger.flush();
 					}
 				},
 			});
@@ -383,6 +391,9 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 
 			// Log error details
 			console.error("[MaximSDK] doStream failed:", error);
+
+			// Flush logs before throwing error
+			await this.logger.flush();
 
 			throw error;
 		} finally {

--- a/src/lib/logger/vercel/v2/wrapperV2.ts
+++ b/src/lib/logger/vercel/v2/wrapperV2.ts
@@ -235,6 +235,7 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 					trace.end();
 				}
 			}
+			await this.logger.flush();
 		}
 	}
 
@@ -333,6 +334,9 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 											trace.end();
 										}
 									}
+
+									// Flush logs after processStreamV2 and tool-result logging complete
+									await wrapperInstance.logger.flush();
 								} catch (error) {
 									console.error("[MaximSDK] Processing failed:", error);
 									if (generation) {
@@ -341,6 +345,8 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 										});
 										generation.end();
 									}
+									// Flush logs even on error
+									await wrapperInstance.logger.flush();
 								}
 
 								// Now close the stream
@@ -365,6 +371,8 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 							});
 							generation.end();
 						}
+						// Flush logs on stream error
+						await wrapperInstance.logger.flush();
 					}
 				},
 			});
@@ -385,6 +393,9 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 			// Log error details
 			console.error("[MaximSDK] doStream failed:", error);
 
+			// Flush logs before throwing error
+			await this.logger.flush();
+
 			throw error;
 		} finally {
 			// End trace if:
@@ -401,6 +412,7 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 					trace.end();
 				}
 			}
+			// Note: flush() is now called after stream completion and in error paths, not here
 		}
 	}
 

--- a/src/lib/logger/vercel/v3/wrapperV3.ts
+++ b/src/lib/logger/vercel/v3/wrapperV3.ts
@@ -255,6 +255,7 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 			this.currentTrace = null;
 			this.isInToolCallSequence = false;
 			trace.end();
+			await this.logger.flush();
 		}
 	}
 
@@ -376,6 +377,9 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 									wrapperInstance.currentTrace = null;
 									wrapperInstance.isInToolCallSequence = false;
 									trace.end();
+
+									// Flush logs after processStreamV3 and tool-result logging complete
+									await wrapperInstance.logger.flush();
 								} catch (error) {
 									console.error("[MaximSDK] Processing failed:", error);
 									if (generation) {
@@ -384,6 +388,8 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 										});
 										generation.end();
 									}
+									// Flush logs even on error
+									await wrapperInstance.logger.flush();
 								}
 
 								// Now close the stream
@@ -408,6 +414,8 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 							});
 							generation.end();
 						}
+						// Flush logs on stream error
+						await wrapperInstance.logger.flush();
 					}
 				},
 			});
@@ -427,6 +435,9 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 
 			// Log error details
 			console.error("[MaximSDK] doStream failed:", error);
+
+			// Flush logs before throwing error
+			await this.logger.flush();
 
 			throw error;
 		} finally {


### PR DESCRIPTION
### TL;DR

Added logger flush calls to ensure all logs are properly sent before functions complete.

### What changed?

- Bumped package version from 6.29.1 to 6.29.2
- Added `await this.logger.flush()` calls at the end of request handling methods in:
  - `MaximAISDKWrapper` (v1)
  - `MaximAISDKWrapperV2` (v2)
  - `MaximAISDKWrapperV3` (v3)

### How to test?

1. Make API calls using the SDK
2. Verify that logs are properly flushed and sent to the logging system
3. Check that no logs are being lost when functions complete

### Why make this change?

This change ensures that all logs are properly flushed and sent to the logging system before the functions complete execution. Without explicit flush calls, there's a risk that some logs might not be sent if the process terminates before the logger has a chance to flush its buffer.