### PR TITLE
[Maxim JS] Adds support for linking test runs with logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,19 +559,24 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 - feat: Adds a new optional field `maximPromptVersionId` in `GenerationConfig`
 
 ### v6.23.0
+
 - feat: Added support for simulationConfig in workflow and prompt test runs, enabling simulation runs
 
 ### v6.22.0
+
 - fix: Fixes AI SDK multiple traces showing same input for session conversations
 
 ### v6.21.0
+
 - fix: Fixes multiple trace issues and same input for tool call executions
 - fix: Uses v2 API for test run entry push
 
 ### v6.20.1
+
 - fix: Adds `tool-input-delta` to be recognized as the first chunk
 
 ### v6.20.0
+
 - feat: Added TTFT and TPS metrics in AI SDK wrappers
 - fix: Fixes input in AI SDK v1 wrapper
 

--- a/src/lib/apis/testRun.ts
+++ b/src/lib/apis/testRun.ts
@@ -4,6 +4,8 @@ import { MaximAPIResponse } from "../models/deployment";
 import { HumanEvaluationConfig, MaximAPIEvaluatorFetchResponse } from "../models/evaluator";
 import {
 	MaximAPICreateTestRunResponse,
+	MaximAPITestRunEntryCreatePayload,
+	MaximAPITestRunEntryCreateResponse,
 	MaximAPITestRunEntryExecutePromptChainForDataPayload,
 	MaximAPITestRunEntryExecutePromptChainForDataResponse,
 	MaximAPITestRunEntryExecutePromptForDataPayload,
@@ -24,7 +26,7 @@ import {
 	TestRunConfig,
 	TestRunResult,
 } from "../models/testRun";
-import type { UrlAttachment } from "../types";
+import type { Attachment, UrlAttachment } from "../types";
 import { ExtractAPIDataType } from "../utils/utils";
 import { MaximAPI } from "./maxim";
 
@@ -45,6 +47,7 @@ export class MaximTestRunAPI extends MaximAPI {
 		humanEvaluationConfig?: HumanEvaluationConfig,
 		tags?: string[],
 		simulationConfig?: TestRunConfig["simulationConfig"],
+		connectedRepoId?: string,
 	): Promise<ExtractAPIDataType<MaximAPICreateTestRunResponse>> {
 		return new Promise((resolve, reject) => {
 			this.fetch<MaximAPICreateTestRunResponse>(`/api/sdk/v2/test-run/create`, {
@@ -65,6 +68,7 @@ export class MaximTestRunAPI extends MaximAPI {
 					humanEvaluationConfig,
 					tags,
 					simulationConfig,
+					connectedRepoId,
 				}),
 			})
 				.then((response) => {
@@ -225,16 +229,145 @@ export class MaximTestRunAPI extends MaximAPI {
 			: (rawDataEntry as Record<string, Variable | undefined>);
 	}
 
+	/**
+	 * Converts Variable format to API format for dataEntry.
+	 * - TEXT Variable -> { type: "text", payload: string }
+	 * - FILE Variable -> { type: "file", payload: { files: [...], text?: string } }
+	 */
+	private convertVariableToAPIFormat(
+		variable: Variable,
+	): { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } {
+		if (variable.type === VariableType.TEXT || variable.type === VariableType.JSON) {
+			return {
+				type: "text",
+				payload: variable.payload,
+			};
+		}
+
+		if (variable.type === VariableType.FILE) {
+			// Convert Attachment[] to API format
+			const files = variable.payload.map((attachment) => {
+				if (attachment.type === "url") {
+					return {
+						id: attachment.id,
+						url: attachment.url,
+						name: attachment.name,
+						type: attachment.mimeType || "application/octet-stream",
+					};
+				} else if (attachment.type === "file") {
+					// For file attachments, we need the URL - this might need to be handled differently
+					// For now, we'll use the path as URL if available
+					return {
+						id: attachment.id,
+						url: attachment.path, // Note: This might need adjustment based on how file paths are handled
+						name: attachment.name,
+						type: attachment.mimeType || "application/octet-stream",
+					};
+				} else {
+					// fileData attachments - these need special handling
+					// For now, we'll create a placeholder structure
+					return {
+						id: attachment.id,
+						url: "", // fileData attachments don't have URLs
+						name: attachment.name,
+						type: attachment.mimeType || "application/octet-stream",
+					};
+				}
+			});
+
+			return {
+				type: "file",
+				payload: {
+					files,
+				},
+			};
+		}
+
+		// Fallback (should not happen)
+		return {
+			type: "text",
+			payload: "",
+		};
+	}
+
+	/**
+	 * Converts dataEntry from Variable format to API format.
+	 * Handles the conversion of FILE variables to the API's expected file structure.
+	 */
+	private convertDataEntryToAPIFormat(
+		dataEntry: Record<string, string | string[] | Variable | null | undefined>,
+	): Record<string, { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } | null | undefined> {
+		const result: Record<string, { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } | null | undefined> = {};
+
+		for (const [key, value] of Object.entries(dataEntry)) {
+			if (value === null || value === undefined) {
+				result[key] = value;
+				continue;
+			}
+
+			if (this.isVariable(value)) {
+				result[key] = this.convertVariableToAPIFormat(value);
+			} else if (typeof value === "string") {
+				result[key] = {
+					type: "text",
+					payload: value,
+				};
+			} else if (Array.isArray(value)) {
+				// Convert string array to file format
+				const files = value.map((url, index) => ({
+					id: `${key}-${index}`,
+					url: url,
+					type: "application/octet-stream",
+				}));
+				result[key] = {
+					type: "file",
+					payload: {
+						files,
+					},
+				};
+			}
+		}
+
+		return result;
+	}
+
+	public async createTestRunEntry({
+		testRun,
+	}: MaximAPITestRunEntryCreatePayload): Promise<ExtractAPIDataType<MaximAPITestRunEntryCreateResponse>> {
+		return new Promise((resolve, reject) => {
+			this.fetch<MaximAPITestRunEntryCreateResponse>(`/api/sdk/v1/test-run/test-run-entry/create`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Accept: "application/json",
+				},
+				body: JSON.stringify({
+					testRun,
+				}),
+			})
+				.then((response) => {
+					if ("error" in response) {
+						reject(response.error);
+					} else {
+						resolve(response.data);
+					}
+				})
+				.catch((error) => {
+					reject(error);
+				});
+		});
+	}
+
 	public async pushTestRunEntry({ testRun, runConfig, entry, localSimulation }: MaximAPITestRunEntryPushPayload): Promise<void> {
 		const convertedEntry = entry.dataEntry
 			? {
 					...entry,
-					dataEntry: this.normalizeDataEntryToVariables(entry.dataEntry),
+					dataEntry: this.convertDataEntryToAPIFormat(entry.dataEntry),
 				}
 			: entry;
 
 		return new Promise((resolve, reject) => {
-			this.fetch<MaximAPIResponse>(`/api/sdk/v2/test-run/push`, {
+			this.fetch<MaximAPIResponse>(`/api/sdk/v4/test-run/push`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/src/lib/models/testRun.ts
+++ b/src/lib/models/testRun.ts
@@ -1,4 +1,5 @@
 import type { Data, DataStructure, DataValue, Variable } from "../models/dataset";
+import type { MaximLogger } from "../logger/logger";
 import type {
 	CombinedLocalEvaluatorType,
 	HumanEvaluationConfig,
@@ -340,6 +341,13 @@ export type TestRunConfig<T extends DataStructure | undefined = undefined> = {
 			turnNumber: number;
 		},
 	) => YieldedOutput | Promise<YieldedOutput>;
+	outputFunctionWithTracing?: (data: Data<T>, traceId: string, simulationContext?: {
+		conversationHistory: SimulationConversationTurn[];
+		currentUserInput: Record<string, unknown>;
+		turnNumber: number;
+	}) => YieldedOutput | Promise<YieldedOutput>;
+	maximLogger?: MaximLogger;
+	disableDefaultTraceCreation?: boolean;
 	promptVersion?: {
 		id: string;
 		contextToEvaluate?: string;
@@ -558,9 +566,11 @@ export type TestRunBuilder<T extends DataStructure | undefined = undefined> = {
 	 *                 },
 	 *             },
 	 *         };
-	 *     });
+	 *     }, maximLogger);
 	 */
-	yieldsOutput: (outputFunction: TestRunConfig<T>["outputFunction"]) => TestRunBuilder<T>;
+	yieldsOutput: (outputFunction: TestRunConfig<T>["outputFunction"], maximLogger?: MaximLogger) => TestRunBuilder<T>;
+
+	yieldsOutputWithTracing: (outputFunction: TestRunConfig<T>["outputFunctionWithTracing"], maximLogger: MaximLogger, disableDefaultTraceCreation?: boolean) => TestRunBuilder<T>;
 
 	/**
 	 * Sets the prompt version ID for the test run. Optionally, you can also set the context to evaluate for the prompt. (Note: setting the context to evaluate will end up overriding the CONTEXT_TO_EVALUATE dataset column value)
@@ -729,6 +739,28 @@ export type MaximAPICreateTestRunResponse =
 			};
 	  };
 
+export type MaximAPITestRunEntryCreatePayload = {
+	testRun: {
+		id: string;
+		datasetEntryId?: string;
+		datasetId?: string;
+		workspaceId: string;
+		humanEvaluationConfig?: {
+			emails: string[];
+			instructions: string;
+			requester: string;
+		};
+		evalConfig: unknown;
+		parentTestRunId?: string;
+	};
+};
+
+export type MaximAPITestRunEntryCreateResponse = {
+	data: {
+		id: string;
+	};
+};
+
 export type MaximAPITestRunEntryPushPayload<T extends DataStructure | undefined = undefined> = {
 	testRun: {
 		id: string;
@@ -765,6 +797,7 @@ export type MaximAPITestRunEntryPushPayload<T extends DataStructure | undefined 
 };
 
 export type MaximAPITestRunEntry = {
+	id?: string;
 	input?: string;
 	expectedOutput?: string;
 	contextToEvaluate?: string | string[];
@@ -774,6 +807,7 @@ export type MaximAPITestRunEntry = {
 	meta?: {
 		variables?: Record<string, Variable>;
 		sdkVariables?: Record<string, Variable>;
+		connectedTraceId?: string;
 	};
 	dataEntry: Record<string, string | string[] | Variable | null | undefined>;
 	localEvaluationResults?: (LocalEvaluationResult & { id: string })[];

--- a/src/lib/testRun/runUtils.ts
+++ b/src/lib/testRun/runUtils.ts
@@ -26,6 +26,21 @@ export async function runOutputFunction<T extends DataStructure | undefined>(
 	}
 }
 
+export async function runOutputFunctionWithTracing<T extends DataStructure | undefined>(
+	outputFunction: NonNullable<TestRunConfig<T>["outputFunctionWithTracing"]>,
+	dataEntry: Data<T>,
+	traceId: string,
+): Promise<ReturnType<NonNullable<TestRunConfig<T>["outputFunctionWithTracing"]>>> {
+	try {
+		const result = await outputFunction(dataEntry, traceId);
+		return result;
+	} catch (err) {
+		throw new Error(`Error while running output function`, {
+			cause: err,
+		});
+	}
+}
+
 /**
  * Runs local evaluations on the data entry.
  * @param evaluators - The evaluators to run

--- a/src/lib/testRun/testRun.ts
+++ b/src/lib/testRun/testRun.ts
@@ -11,7 +11,7 @@ import type {
 	PassFailCriteriaType,
 	PlatformEvaluator,
 } from "../models/evaluator";
-import type { TestRunBuilder, TestRunConfig, YieldedOutput } from "../models/testRun";
+import type { TestRunBuilder, TestRunConfig } from "../models/testRun";
 
 import { CSVFile } from "../utils/csvParser";
 import { Semaphore } from "../utils/semaphore";
@@ -27,10 +27,13 @@ import {
 	simulationPromptVersionIdOutputFunctionClosure,
 	simulationWorkflowIdOutputFunctionClosure,
 	simulationYieldsOutputFunctionClosure,
+	runOutputFunctionWithTracing,
 	workflowIdOutputFunctionClosure,
 } from "./runUtils";
 import { sanitizeData, sanitizeEvaluators } from "./sanitizationUtils";
 import { buildErrorMessage, calculatePollingInterval, createStatusTable, getLocalEvaluatorNameToIdAndPassFailCriteriaMap } from "./utils";
+import { MaximLogger } from "../logger/logger";
+import { v4 as uuidv4 } from "uuid";
 
 /**
  * Creates a new TestRunBuilder with the given configuration.
@@ -64,6 +67,8 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 	withWorkflowId: (id, contextToEvaluate) => createTestRunBuilder({ ...config, workflow: { id, contextToEvaluate } }),
 	withSimulationConfig: (simulationConfig) => createTestRunBuilder({ ...config, simulationConfig }),
 	yieldsOutput: (outputFunction) => createTestRunBuilder({ ...config, outputFunction }),
+	yieldsOutputWithTracing: (outputFunctionWithTracing, maximLogger, disableDefaultTraceCreation) =>
+		createTestRunBuilder({ ...config, outputFunctionWithTracing, maximLogger, disableDefaultTraceCreation: disableDefaultTraceCreation ?? false }),
 	withLogger: (logger) => createTestRunBuilder({ ...config, logger }),
 	getConfig: () => config,
 	withConcurrency: (concurrency) => createTestRunBuilder({ ...config, concurrency }),
@@ -80,16 +85,23 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 		if (!config.workspaceId) {
 			errors.push("Workspace Id is required to run a test.");
 		}
-		if (!config.outputFunction && !config.promptVersion && !config.promptChainVersion && !config.workflow) {
+		if (
+			!config.outputFunction &&
+			!config.outputFunctionWithTracing &&
+			!config.promptVersion &&
+			!config.promptChainVersion &&
+			!config.workflow
+		) {
 			errors.push(
-				"Output function or prompt version id, prompt chain version id, or workflow id is required to run a test. You can use either yieldsOutput, withPromptVersionId, withPromptChainVersionId or withWorkflowId to set them respectively.",
+				"Output function or prompt version id, prompt chain version id, or workflow id is required to run a test. You can use either yieldsOutput, yieldsOutputWithTracing, withPromptVersionId, withPromptChainVersionId or withWorkflowId to set them respectively.",
 			);
 		}
 		const hasOutputFunction = !!config.outputFunction;
 		const hasPromptVersion = !!config.promptVersion;
 		const hasPromptChainVersion = !!config.promptChainVersion;
 		const hasWorkflow = !!config.workflow;
-		const outputSourceCount = (hasOutputFunction ? 1 : 0) + (hasPromptVersion ? 1 : 0) + (hasPromptChainVersion ? 1 : 0) + (hasWorkflow ? 1 : 0);
+		const hasOutputFunctionWithTracing = !!config.outputFunctionWithTracing;
+		const outputSourceCount = (hasOutputFunction ? 1 : 0) + (hasOutputFunctionWithTracing ? 1 : 0) + (hasPromptVersion ? 1 : 0) + (hasPromptChainVersion ? 1 : 0) + (hasWorkflow ? 1 : 0);
 
 		// Simulation + yieldsOutput: requires outputFunction + (promptVersion OR workflow)
 		if (config.simulationConfig && hasOutputFunction) {
@@ -109,14 +121,17 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 			errors.push("Data or dataset id is required to run a test.");
 		}
 		if (config.simulationConfig) {
+			if (config.outputFunctionWithTracing) {
+				errors.push("Simulation config cannot be used with yieldsOutputWithTracing. Use yieldsOutput instead.");
+			}
 			if (config.promptChainVersion) {
 				errors.push("Simulation config cannot be used with withPromptChainVersionId. Use withWorkflowId, withPromptVersionId, or yieldsOutput instead.");
 			}
 			if (!config.workflow && !config.promptVersion && !config.outputFunction) {
-				errors.push("Simulation config requires either withWorkflowId, withPromptVersionId, or yieldsOutput to be set.");
+				errors.push("Simulation config requires either withWorkflowId, withPromptVersionId, yieldsOutput to be set.");
 			}
 			if (config.simulationConfig.responseFields && config.simulationConfig.responseFields.length > 0 && !config.workflow) {
-				errors.push("responseFields in simulationConfig can only be used with withWorkflowId, not with withPromptVersionId or yieldsOutput.");
+				errors.push("responseFields in simulationConfig can only be used with withWorkflowId, not with withPromptVersionId, yieldsOutput or yieldsOutputWithTracing.");
 			}
 		}
 
@@ -159,11 +174,13 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 		const evaluators = config.evaluators;
 		const humanEvaluationConfig = config.humanEvaluationConfig;
 		const outputFunction = config.outputFunction;
+		const outputFunctionWithTracing = config.outputFunctionWithTracing;
 		const promptVersion = config.promptVersion;
 		const promptChainVersion = config.promptChainVersion;
 		const workflow = config.workflow;
 		const tags = config.tags;
 		const failedEntryIndices: number[] = [];
+		let internalMaximLogger: MaximLogger | undefined = undefined;
 		const localEvaluatorNameToIdAndPassFailCriteriaMap = getLocalEvaluatorNameToIdAndPassFailCriteriaMap(
 			evaluators.filter(
 				(e): e is LocalEvaluatorType<T> | CombinedLocalEvaluatorType<T, Record<string, PassFailCriteriaType>> =>
@@ -409,12 +426,16 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 
 				return;
 			} // Make sure if its local workflow or remote workflow
-			else if (outputFunction || evaluators.filter((e) => typeof e !== "string").length > 0) {
-				let outputFunctionToExecute: (data: Data<T>) => YieldedOutput | Promise<YieldedOutput>;
+			else if (outputFunction || outputFunctionWithTracing || evaluators.filter((e) => typeof e !== "string").length > 0) {
+			// Make sure if its local workflow or remote workflow
+				let outputFunctionToExecute: NonNullable<TestRunConfig<T>["outputFunction"]> | undefined;
+				let outputFunctionWithTracingToExecute: NonNullable<TestRunConfig<T>["outputFunctionWithTracing"]> | undefined;
+
 				if (outputFunction) {
 					outputFunctionToExecute = outputFunction;
-				}
-				else {
+				} else if (outputFunctionWithTracing) {
+					outputFunctionWithTracingToExecute = outputFunctionWithTracing;
+				} else {
 					// Check if we need to use simulation endpoints (simulationConfig + local evaluators)
 					const hasLocalEvaluators =
 						evaluators.filter((e) => typeof e !== "string" && "evaluationFunction" in e).length > 0;
@@ -477,18 +498,38 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 						);
 					} else {
 						throw new Error(
-							"Found no output function to execute, please make sure you have either `yieldsOutput`, `withPromptVersionId`, `withPromptChainVersionId` or `withWorkflowId` set.",
+							"Found no output function to execute, please make sure you have either `yieldsOutput`, `yieldsOutputWithTracing`, `withPromptVersionId`, `withPromptChainVersionId` or `withWorkflowId` set.",
 						);
 					}
 				}
 
-				const output = await runOutputFunction(outputFunctionToExecute, row.data);
+				const testRunEntry = await APITestRunService.createTestRunEntry({
+					testRun: { ...testRun, datasetId, datasetEntryId: row.id },
+				});
+
+				const traceId = uuidv4();
+				if (!config.disableDefaultTraceCreation && internalMaximLogger) {
+					try {
+						const testRunEntryTrace = internalMaximLogger.trace({
+							id: traceId,
+							name: `Test Run Entry ${index + 1}`,
+						})
+						testRunEntryTrace.addTag("testRunEntryId", testRunEntry.id);
+						testRunEntryTrace.addTag("testRunId", testRun.id);
+					} catch (e) {
+						logger.error(`Error creating trace for test run entry ${index + 1}: ${e instanceof Error ? e.message : String(e)}`);
+					}
+				}
+
+				const output =
+					outputFunctionWithTracingToExecute !== undefined
+						? await runOutputFunctionWithTracing(outputFunctionWithTracingToExecute, row.data, traceId)
+						: await runOutputFunction(outputFunctionToExecute!, row.data);
 
 				if (output.retrievedContextToEvaluate) {
 					if (contextToEvaluate) {
 						logger.info(
-							`Detected retrieved context returned from output function for row ${
-								index + 1
+							`Detected retrieved context returned from output function for row ${index + 1
 							} that had contextToEvaluate set from the dataset.\nOverriding the contextToEvaluate from dataset with the retrieved context`,
 						);
 					}
@@ -572,19 +613,19 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 							try {
 								const version = workflow
 									? {
-											id: workflow.id,
-											type: "workflow" as const,
-										}
+										id: workflow.id,
+										type: "workflow" as const,
+									}
 									: promptVersion
 										? {
-												id: promptVersion.id,
-												type: "prompt" as const,
-											}
+											id: promptVersion.id,
+											type: "prompt" as const,
+										}
 										: promptChainVersion
 											? {
-													id: promptChainVersion.id,
-													type: "promptChain" as const,
-												}
+												id: promptChainVersion.id,
+												type: "promptChain" as const,
+											}
 											: undefined;
 
 								mappingResult[key] = mappingFn(runObj, row.data, version);
@@ -597,57 +638,60 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				}
 
 				try {
-					await APITestRunService.pushTestRunEntry({
-						testRun: { ...testRun, datasetId, datasetEntryId: row.id },
-						runConfig: output.meta
-							? {
-									cost: output.meta.cost,
-									usage: output.meta.usage
-										? "completionTokens" in output.meta.usage
-											? {
-													completion_tokens: output.meta.usage.completionTokens,
-													prompt_tokens: output.meta.usage.promptTokens,
-													total_tokens: output.meta.usage.totalTokens,
-													latency: output.meta.usage.latency,
-												}
-											: {
-													latency: output.meta.usage.latency,
-												}
-										: undefined,
-								}
-							: undefined,
-						entry: {
-							input,
-							output: output.data,
-							meta: {
-								sdkVariables:
-									evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
-										? Object.entries(evaluatorOutputOverrides).reduce(
-												(acc, [id, val]) => {
-													acc[id] = {
-														type: VariableType.JSON,
-														payload: JSON.stringify(val),
-													};
-													return acc;
-												},
-												{} as Record<string, Variable>,
-											)
-										: undefined,
-							},
-							expectedOutput,
-							contextToEvaluate,
-							scenario,
-							expectedSteps,
-							dataEntry: row.data,
-							localEvaluationResults: localEvaluationResults
-								? localEvaluationResults.map((result) => ({
-										...result,
-										id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
-									}))
+				await APITestRunService.pushTestRunEntry({
+					testRun: { ...testRun, datasetId, datasetEntryId: row.id },
+					runConfig: output.meta
+						? {
+							cost: output.meta.cost,
+							usage: output.meta.usage
+								? "completionTokens" in output.meta.usage
+									? {
+										completion_tokens: output.meta.usage.completionTokens,
+										prompt_tokens: output.meta.usage.promptTokens,
+										total_tokens: output.meta.usage.totalTokens,
+										latency: output.meta.usage.latency,
+									}
+									: {
+										latency: output.meta.usage.latency,
+									}
 								: undefined,
-							simulationMeta: output.simulationMeta,
+						}
+						: undefined,
+					entry: {
+						id: testRunEntry.id,
+						input,
+						output: output.data,
+						meta: {
+							sdkVariables:
+								evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
+									? Object.entries(evaluatorOutputOverrides).reduce(
+										(acc, [id, val]) => {
+											acc[id] = {
+												type: VariableType.JSON,
+												payload: JSON.stringify(val),
+											};
+											return acc;
+										},
+										{} as Record<string, Variable>,
+									)
+									: undefined,
+							connectedTraceId: internalMaximLogger ? traceId : undefined,
 						},
-					});
+						expectedOutput,
+						contextToEvaluate,
+						scenario,
+						expectedSteps,
+						dataEntry: row.data,
+						localEvaluationResults: localEvaluationResults
+							? localEvaluationResults.map((result) => ({
+								...result,
+								id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
+							}))
+							: undefined,
+						simulationMeta: output.simulationMeta,
+					},
+				});
+					
 				} catch (pushError) {
 					const testRunEntryId = output?.simulationMeta?.testRunEntryId;
 					if (testRunEntryId) {
@@ -739,6 +783,12 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				),
 			];
 
+			if (config.maximLogger) {
+				internalMaximLogger = config.maximLogger;
+			}
+
+			const tagsEnrichedWithRepoId = config.maximLogger ? [...(tags ?? []), `repoId:${config.maximLogger.id}`] : tags;
+
 			const testRun = await APITestRunService.createTestRun(
 				name,
 				workspaceId,
@@ -749,8 +799,9 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				promptVersion?.id,
 				promptChainVersion?.id,
 				humanEvaluationConfig,
-				tags,
+				tagsEnrichedWithRepoId,
 				config.simulationConfig,
+				internalMaximLogger?.id,
 			);
 
 			try {
@@ -974,8 +1025,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 										logger.error(
 											buildErrorMessage(
 												new Error(
-													`=> Skipping page ${page - 1}\nError while sanitizing reponse as per data structure: ${
-														err.message
+													`=> Skipping page ${page - 1}\nError while sanitizing reponse as per data structure: ${err.message
 													}\n\tGot response: ${JSON.stringify(fetchedData)}`,
 													{
 														cause: err,
@@ -987,8 +1037,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 										logger.error(
 											buildErrorMessage(
 												new Error(
-													`=> Skipping page ${
-														page - 1
+													`=> Skipping page ${page - 1
 													}\nError while sanitizing reponse as per data structure\n\tGot response: ${JSON.stringify(fetchedData)}`,
 													{
 														cause: err,
@@ -1107,8 +1156,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 					throw new Error(
 						`Test run is taking over timeout period (${Math.round(
 							timeoutInMinutes,
-						)} minutes) to complete, please check the report on our web portal directly: ${config.baseUrl}/workspace/${
-							config.workspaceId
+						)} minutes) to complete, please check the report on our web portal directly: ${config.baseUrl}/workspace/${config.workspaceId
 						}/testrun/${testRun.id}`,
 					);
 				}

--- a/src/lib/tests/testRuns/testRun.ts
+++ b/src/lib/tests/testRuns/testRun.ts
@@ -1,0 +1,85 @@
+import { createDataStructure } from "src/lib/dataset/dataset";
+import { Maxim } from "../../maxim";
+import "dotenv/config";
+import { Data } from "src/lib/models/dataset";
+import axios from "axios";
+
+
+if (!process.env["MAXIM_API_KEY"]) throw new Error("Missing MAXIM_API_KEY environment variable");
+if (!process.env["MAXIM_WORKSPACE_ID"]) throw new Error("Missing MAXIM_WORKSPACE_ID environment variable");
+if (!process.env["MAXIM_LOG_REPO_ID"]) throw new Error("Missing MAXIM_LOG_REPO_ID environment variable");
+
+const maxim = new Maxim({
+  apiKey: process.env["MAXIM_API_KEY"],
+  baseUrl: process.env["MAXIM_BASE_URL"],
+});
+
+const dataStructure = createDataStructure({
+  Input: "INPUT",
+  "Expected Output": "EXPECTED_OUTPUT",
+  targetLanguage: "VARIABLE",
+  nativeLanguage: "VARIABLE",
+  difficulty: "VARIABLE",
+});
+
+const data = [
+  {
+    Input: "How to say Hello",
+    "Expected Output": "To say \"Hello\" in Spanish, you say \"Hola.\" \n\nCan you try saying it? \nAlso, you can use \"Hola\" in different situations, just like in English! \n\nFor example: \n\n- \"Hola, ¿cómo estás?\" (Hello, how are you?) \n\nWould you like to learn how to respond to that question?",
+    targetLanguage: "Klingon",
+    nativeLanguage: "English",
+    difficulty: "beginner",
+  },
+  {
+    Input: "How to say Good",
+    "Expected Output": "Great question! In Spanish, \"good\" is \"bueno.\" \n\nHere's how you can use it in a sentence:\n\n- \"Es bueno.\" (It is good.)\n- \"El libro es bueno.\" (The book is good.)\n\nCan you try to use \"bueno\" in a sentence",
+    targetLanguage: "Klingon",
+    nativeLanguage: "English",
+    difficulty: "beginner",
+  },
+];
+
+async function main() {
+  const maximLogger = await maxim.logger({ id: process.env["MAXIM_LOG_REPO_ID"]! });
+
+  const testRun = maxim
+    .createTestRun("testing tests + logs", process.env["MAXIM_WORKSPACE_ID"]!)
+    .withDataStructure(dataStructure)
+    .withData(data)
+    .withConcurrency(2)
+    .yieldsOutputWithTracing(async (data: Data<typeof dataStructure>, traceId: string) => {
+      const response = await axios.post("http://localhost:3001/api/v1/chat", {
+        message: data.Input,
+        targetLanguage: data.targetLanguage,
+        nativeLanguage: data.nativeLanguage,
+        difficulty: data.difficulty,
+      }, {
+        headers: {
+          "trace-id": traceId,
+        },
+      });
+
+      const content = response.data.data?.choices[0]?.message?.content || "";
+      const usage = response.data.data?.usage;
+
+      return {
+        data: content,
+        meta: {
+          usage: {
+            totalTokens: usage?.total_tokens || 0,
+            completionTokens: usage?.completion_tokens || 0,
+            promptTokens: usage?.prompt_tokens || 0,
+          },
+          cost: {
+            input: (usage?.prompt_tokens || 0) * 0.0015,
+            output: (usage?.completion_tokens || 0) * 0.002,
+            total: (usage?.total_tokens || 0) * 0.00175,
+          },
+        },
+      };
+    }, maximLogger!, true);
+
+  await testRun.run();
+}
+
+main().catch(console.error);


### PR DESCRIPTION
### TL;DR

Added support for linking test runs with logs through a new `yieldsOutputWithTracing` method.

### What changed?

- Added a new `yieldsOutputWithTracing` method to the TestRunBuilder that allows connecting test runs with traces
- Created a mechanism to link test run entries with trace IDs
- Updated the API endpoints to support the new functionality
- Added support for passing a MaximLogger instance to test runs
- Improved data entry conversion to API format for better handling of file variables
- Added an option to disable default trace creation
- Bumped version to 6.30.0

### How to test?

A new test file has been added at `src/lib/tests/testRuns/testRun.ts` that demonstrates how to use the new functionality:

```typescript
const testRun = maxim
  .createTestRun("testing tests + logs", workspaceId)
  .withDataStructure(dataStructure)
  .withData(data)
  .withConcurrency(2)
  .yieldsOutputWithTracing(async (data, traceId) => {
    // Make API call with traceId in headers
    const response = await axios.post("http://localhost:3001/api/v1/chat", {
      message: data.Input,
      // other data...
    }, {
      headers: {
        "trace-id": traceId,
      },
    });
    
    // Return output
    return {
      data: response.data.data?.choices[0]?.message?.content || "",
      // meta information...
    };
  }, maximLogger, true);

await testRun.run();
```

### Why make this change?

This change enables better integration between test runs and logging, allowing users to correlate test run entries with specific traces. This is particularly useful for debugging and analyzing test results, as it provides a direct link between test data and the corresponding logs. The feature helps users track the execution flow and performance metrics of their tests more effectively.