### PR TITLE
[Maxim JS]: adding support for yields output with simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,19 +559,24 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 - feat: Adds a new optional field `maximPromptVersionId` in `GenerationConfig`
 
 ### v6.23.0
+
 - feat: Added support for simulationConfig in workflow and prompt test runs, enabling simulation runs
 
 ### v6.22.0
+
 - fix: Fixes AI SDK multiple traces showing same input for session conversations
 
 ### v6.21.0
+
 - fix: Fixes multiple trace issues and same input for tool call executions
 - fix: Uses v2 API for test run entry push
 
 ### v6.20.1
+
 - fix: Adds `tool-input-delta` to be recognized as the first chunk
 
 ### v6.20.0
+
 - feat: Added TTFT and TPS metrics in AI SDK wrappers
 - fix: Fixes input in AI SDK v1 wrapper
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,12 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 
 ## Version changelog
 
+### v6.30.2
+
+- feat: Adds support for `simulation` with `yieldsOutput`
+- feat: Adds support for linking test runs with logs
+
+
 ### v6.30.1
 
 - feat: Adds `elevenlabs` to providers lists for generation type check

--- a/index.ts
+++ b/index.ts
@@ -54,7 +54,15 @@ export type {
 	ToolCallFunction,
 } from "./src/lib/models/prompt";
 export * from "./src/lib/models/queryBuilder";
-export type { TestRunBuilder, TestRunConfig, TestRunLogger, TestRunResult, YieldedOutput } from "./src/lib/models/testRun";
+export type {
+	SimulationConversationTurn,
+	SimulationMeta,
+	TestRunBuilder,
+	TestRunConfig,
+	TestRunLogger,
+	TestRunResult,
+	YieldedOutput,
+} from "./src/lib/models/testRun";
 export * from "./src/lib/utils/csvParser";
 export * from "./src/lib/utils/secureRandom";
 // Additional exports for complete documentation coverage

--- a/index.ts
+++ b/index.ts
@@ -55,6 +55,8 @@ export type {
 } from "./src/lib/models/prompt";
 export * from "./src/lib/models/queryBuilder";
 export type {
+	CustomSimulatorConfig,
+	SimulationContext,
 	SimulationConversationTurn,
 	SimulationMeta,
 	TestRunBuilder,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.30.1",
+	"version": "6.30.2",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",
@@ -59,7 +59,9 @@
 	"peerDependencies": {
 		"@types/mime-types": "3.0.1",
 		"expo-crypto": "^13.0.0",
-		"mime-types": "3.0.1"
+		"mime-types": "3.0.1",
+		"axios": "^1.11.0",
+		"axios-retry": "^4.5.0"
 	},
 	"publishConfig": {
 		"access": "public"
@@ -109,10 +111,6 @@
 			"types": "./openai-sdk.d.ts",
 			"default": "./openai-sdk.js"
 		}
-	},
-	"dependencies": {
-		"axios": "^1.11.0",
-		"axios-retry": "^4.5.0"
 	},
 	"peerDependenciesMeta": {
 		"expo-crypto": {

--- a/src/lib/apis/testRun.ts
+++ b/src/lib/apis/testRun.ts
@@ -4,6 +4,8 @@ import { MaximAPIResponse } from "../models/deployment";
 import { HumanEvaluationConfig, MaximAPIEvaluatorFetchResponse } from "../models/evaluator";
 import {
 	MaximAPICreateTestRunResponse,
+	MaximAPITestRunEntryCreatePayload,
+	MaximAPITestRunEntryCreateResponse,
 	MaximAPITestRunEntryExecutePromptChainForDataPayload,
 	MaximAPITestRunEntryExecutePromptChainForDataResponse,
 	MaximAPITestRunEntryExecutePromptForDataPayload,
@@ -24,7 +26,7 @@ import {
 	TestRunConfig,
 	TestRunResult,
 } from "../models/testRun";
-import type { UrlAttachment } from "../types";
+import type { Attachment, UrlAttachment } from "../types";
 import { ExtractAPIDataType } from "../utils/utils";
 import { MaximAPI } from "./maxim";
 
@@ -45,6 +47,7 @@ export class MaximTestRunAPI extends MaximAPI {
 		humanEvaluationConfig?: HumanEvaluationConfig,
 		tags?: string[],
 		simulationConfig?: TestRunConfig["simulationConfig"],
+		connectedRepoId?: string,
 	): Promise<ExtractAPIDataType<MaximAPICreateTestRunResponse>> {
 		return new Promise((resolve, reject) => {
 			this.fetch<MaximAPICreateTestRunResponse>(`/api/sdk/v2/test-run/create`, {
@@ -65,6 +68,7 @@ export class MaximTestRunAPI extends MaximAPI {
 					humanEvaluationConfig,
 					tags,
 					simulationConfig,
+					connectedRepoId,
 				}),
 			})
 				.then((response) => {
@@ -225,16 +229,145 @@ export class MaximTestRunAPI extends MaximAPI {
 			: (rawDataEntry as Record<string, Variable | undefined>);
 	}
 
+	/**
+	 * Converts Variable format to API format for dataEntry.
+	 * - TEXT Variable -> { type: "text", payload: string }
+	 * - FILE Variable -> { type: "file", payload: { files: [...], text?: string } }
+	 */
+	private convertVariableToAPIFormat(
+		variable: Variable,
+	): { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } {
+		if (variable.type === VariableType.TEXT || variable.type === VariableType.JSON) {
+			return {
+				type: "text",
+				payload: variable.payload,
+			};
+		}
+
+		if (variable.type === VariableType.FILE) {
+			// Convert Attachment[] to API format
+			const files = variable.payload.map((attachment) => {
+				if (attachment.type === "url") {
+					return {
+						id: attachment.id,
+						url: attachment.url,
+						name: attachment.name,
+						type: attachment.mimeType || "application/octet-stream",
+					};
+				} else if (attachment.type === "file") {
+					// For file attachments, we need the URL - this might need to be handled differently
+					// For now, we'll use the path as URL if available
+					return {
+						id: attachment.id,
+						url: attachment.path, // Note: This might need adjustment based on how file paths are handled
+						name: attachment.name,
+						type: attachment.mimeType || "application/octet-stream",
+					};
+				} else {
+					// fileData attachments - these need special handling
+					// For now, we'll create a placeholder structure
+					return {
+						id: attachment.id,
+						url: "", // fileData attachments don't have URLs
+						name: attachment.name,
+						type: attachment.mimeType || "application/octet-stream",
+					};
+				}
+			});
+
+			return {
+				type: "file",
+				payload: {
+					files,
+				},
+			};
+		}
+
+		// Fallback (should not happen)
+		return {
+			type: "text",
+			payload: "",
+		};
+	}
+
+	/**
+	 * Converts dataEntry from Variable format to API format.
+	 * Handles the conversion of FILE variables to the API's expected file structure.
+	 */
+	private convertDataEntryToAPIFormat(
+		dataEntry: Record<string, string | string[] | Variable | null | undefined>,
+	): Record<string, { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } | null | undefined> {
+		const result: Record<string, { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } | null | undefined> = {};
+
+		for (const [key, value] of Object.entries(dataEntry)) {
+			if (value === null || value === undefined) {
+				result[key] = value;
+				continue;
+			}
+
+			if (this.isVariable(value)) {
+				result[key] = this.convertVariableToAPIFormat(value);
+			} else if (typeof value === "string") {
+				result[key] = {
+					type: "text",
+					payload: value,
+				};
+			} else if (Array.isArray(value)) {
+				// Convert string array to file format
+				const files = value.map((url, index) => ({
+					id: `${key}-${index}`,
+					url: url,
+					type: "application/octet-stream",
+				}));
+				result[key] = {
+					type: "file",
+					payload: {
+						files,
+					},
+				};
+			}
+		}
+
+		return result;
+	}
+
+	public async createTestRunEntry({
+		testRun,
+	}: MaximAPITestRunEntryCreatePayload): Promise<ExtractAPIDataType<MaximAPITestRunEntryCreateResponse>> {
+		return new Promise((resolve, reject) => {
+			this.fetch<MaximAPITestRunEntryCreateResponse>(`/api/sdk/v1/test-run/test-run-entry/create`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Accept: "application/json",
+				},
+				body: JSON.stringify({
+					testRun,
+				}),
+			})
+				.then((response) => {
+					if ("error" in response) {
+						reject(response.error);
+					} else {
+						resolve(response.data);
+					}
+				})
+				.catch((error) => {
+					reject(error);
+				});
+		});
+	}
+
 	public async pushTestRunEntry({ testRun, runConfig, entry, localSimulation }: MaximAPITestRunEntryPushPayload): Promise<void> {
 		const convertedEntry = entry.dataEntry
 			? {
 					...entry,
-					dataEntry: this.normalizeDataEntryToVariables(entry.dataEntry),
+					dataEntry: this.convertDataEntryToAPIFormat(entry.dataEntry),
 				}
 			: entry;
 
 		return new Promise((resolve, reject) => {
-			this.fetch<MaximAPIResponse>(`/api/sdk/v2/test-run/push`, {
+			this.fetch<MaximAPIResponse>(`/api/sdk/v4/test-run/push`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/src/lib/apis/testRun.ts
+++ b/src/lib/apis/testRun.ts
@@ -19,6 +19,8 @@ import {
 	MaximAPITestRunEntryPushPayload,
 	MaximAPITestRunResultResponse,
 	MaximAPITestRunStatusResponse,
+	MaximAPITestRunSimulationLocalExecutionPayload,
+	MaximAPITestRunSimulationLocalExecutionPostResponse,
 	TestRunConfig,
 	TestRunResult,
 } from "../models/testRun";
@@ -88,6 +90,32 @@ export class MaximTestRunAPI extends MaximAPI {
 				},
 				body: JSON.stringify({
 					testRunId,
+				}),
+			})
+				.then((response) => {
+					if (response.error) {
+						reject(response.error);
+					} else {
+						resolve();
+					}
+				})
+				.catch((error) => {
+					reject(error);
+				});
+		});
+	}
+
+	public async updateSimulationStatus(testRunEntryId: string, status: "FAILED"): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			this.fetch<MaximAPIResponse>(`/api/sdk/v2/test-run/simulation/update-status`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Accept: "application/json",
+				},
+				body: JSON.stringify({
+					testRunEntryId,
+					status,
 				}),
 			})
 				.then((response) => {
@@ -197,7 +225,7 @@ export class MaximTestRunAPI extends MaximAPI {
 			: (rawDataEntry as Record<string, Variable | undefined>);
 	}
 
-	public async pushTestRunEntry({ testRun, runConfig, entry }: MaximAPITestRunEntryPushPayload): Promise<void> {
+	public async pushTestRunEntry({ testRun, runConfig, entry, localSimulation }: MaximAPITestRunEntryPushPayload): Promise<void> {
 		const convertedEntry = entry.dataEntry
 			? {
 					...entry,
@@ -216,6 +244,7 @@ export class MaximTestRunAPI extends MaximAPI {
 					testRun,
 					runConfig,
 					entry: convertedEntry,
+					...(localSimulation !== undefined && { localSimulation }),
 				}),
 			})
 				.then((response) => {
@@ -542,6 +571,140 @@ export class MaximTestRunAPI extends MaximAPI {
 					headers: {
 						Accept: "application/json",
 					},
+				},
+			)
+				.then((response) => {
+					if ("error" in response) {
+						reject(response.error);
+					} else {
+						resolve(response.data);
+					}
+				})
+				.catch((error) => {
+					reject(error);
+				});
+		});
+	}
+
+	public async executeSimulationLocalPromptExecution({
+		testRunId,
+		workspaceId,
+		promptVersionId,
+		datasetEntryId,
+		entry,
+		simulationConfig,
+		conversationHistory,
+		testRunEntryId,
+	}: MaximAPITestRunSimulationLocalExecutionPayload): Promise<
+		ExtractAPIDataType<MaximAPITestRunSimulationLocalExecutionPostResponse>
+	> {
+		const resolvedPersona = simulationConfig?.persona
+			? typeof simulationConfig.persona === "string"
+				? simulationConfig.persona
+				: String(
+						(entry?.dataEntry as Record<string, unknown>)?.[simulationConfig.persona.payload] ?? "",
+					)
+			: undefined;
+
+		const convertedEntry =
+			entry?.dataEntry != null
+				? {
+						...entry,
+						dataEntry: this.normalizeDataEntryToVariables(
+							entry.dataEntry as Record<string, string | string[] | Variable | null | undefined>,
+						),
+						...(resolvedPersona !== undefined && { persona: resolvedPersona }),
+					}
+				: entry
+					? { ...entry, ...(resolvedPersona !== undefined && { persona: resolvedPersona }) }
+					: entry;
+
+		return new Promise((resolve, reject) => {
+			this.fetch<MaximAPITestRunSimulationLocalExecutionPostResponse>(
+				`/api/sdk/v2/test-run/simulation/prompt/local-execution`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Accept: "application/json",
+					},
+					body: JSON.stringify({
+						testRunId,
+						workspaceId,
+						promptVersionId,
+						datasetEntryId,
+						entry: convertedEntry,
+						simulationConfig,
+						conversationHistory,
+						testRunEntryId,
+					}),
+				},
+			)
+				.then((response) => {
+					if ("error" in response) {
+						reject(response.error);
+					} else {
+						resolve(response.data);
+					}
+				})
+				.catch((error) => {
+					reject(error);
+				});
+		});
+	}
+
+	public async executeSimulationLocalWorkflowExecution({
+		testRunId,
+		workspaceId,
+		workflowId,
+		datasetEntryId,
+		entry,
+		simulationConfig,
+		conversationHistory,
+		testRunEntryId,
+	}: MaximAPITestRunSimulationLocalExecutionPayload): Promise<
+		ExtractAPIDataType<MaximAPITestRunSimulationLocalExecutionPostResponse>
+	> {
+		const resolvedPersona = simulationConfig?.persona
+			? typeof simulationConfig.persona === "string"
+				? simulationConfig.persona
+				: String(
+						(entry?.dataEntry as Record<string, unknown>)?.[simulationConfig.persona.payload] ?? "",
+					)
+			: undefined;
+
+		const convertedEntry =
+			entry?.dataEntry != null
+				? {
+						...entry,
+						dataEntry: this.normalizeDataEntryToVariables(
+							entry.dataEntry as Record<string, string | string[] | Variable | null | undefined>,
+						),
+						...(resolvedPersona !== undefined && { persona: resolvedPersona }),
+					}
+				: entry
+					? { ...entry, ...(resolvedPersona !== undefined && { persona: resolvedPersona }) }
+					: entry;
+
+		return new Promise((resolve, reject) => {
+			this.fetch<MaximAPITestRunSimulationLocalExecutionPostResponse>(
+				`/api/sdk/v2/test-run/simulation/workflow/local-execution`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Accept: "application/json",
+					},
+					body: JSON.stringify({
+						testRunId,
+						workspaceId,
+						workflowId,
+						datasetEntryId,
+						entry: convertedEntry,
+						simulationConfig,
+						conversationHistory,
+						testRunEntryId,
+					}),
 				},
 			)
 				.then((response) => {

--- a/src/lib/apis/testRun.ts
+++ b/src/lib/apis/testRun.ts
@@ -10,23 +10,26 @@ import {
 	MaximAPITestRunEntryExecutePromptChainForDataResponse,
 	MaximAPITestRunEntryExecutePromptForDataPayload,
 	MaximAPITestRunEntryExecutePromptForDataResponse,
+	MaximAPITestRunEntryExecuteSimulationPromptGetResponse,
 	MaximAPITestRunEntryExecuteSimulationPromptPayload,
 	MaximAPITestRunEntryExecuteSimulationPromptPostResponse,
-	MaximAPITestRunEntryExecuteSimulationPromptGetResponse,
+	MaximAPITestRunEntryExecuteSimulationWorkflowGetResponse,
 	MaximAPITestRunEntryExecuteSimulationWorkflowPayload,
 	MaximAPITestRunEntryExecuteSimulationWorkflowPostResponse,
-	MaximAPITestRunEntryExecuteSimulationWorkflowGetResponse,
 	MaximAPITestRunEntryExecuteWorkflowForDataPayload,
 	MaximAPITestRunEntryExecuteWorkflowForDataResponse,
 	MaximAPITestRunEntryPushPayload,
 	MaximAPITestRunResultResponse,
-	MaximAPITestRunStatusResponse,
 	MaximAPITestRunSimulationLocalExecutionPayload,
 	MaximAPITestRunSimulationLocalExecutionPostResponse,
+	MaximAPITestRunSimulationLocalExecutionRawResponse,
+	MaximAPITestRunStatusResponse,
 	TestRunConfig,
 	TestRunResult,
 } from "../models/testRun";
-import type { Attachment, UrlAttachment } from "../types";
+import { MaximAPISignedURLResponse } from "../models/attachment";
+import type { Attachment, FileAttachment, FileDataAttachment, UrlAttachment } from "../types";
+import { platform } from "../platform";
 import { ExtractAPIDataType } from "../utils/utils";
 import { MaximAPI } from "./maxim";
 
@@ -230,60 +233,121 @@ export class MaximTestRunAPI extends MaximAPI {
 	}
 
 	/**
-	 * Converts Variable format to API format for dataEntry.
-	 * - TEXT Variable -> { type: "text", payload: string }
-	 * - FILE Variable -> { type: "file", payload: { files: [...], text?: string } }
+	 * Signed upload URL for log-repository attachments (same service as {@link MaximAttachmentAPI}).
 	 */
-	private convertVariableToAPIFormat(
+	private async getLogAttachmentUploadUrl(
+		key: string,
+		mimeType: string,
+		size: number,
+	): Promise<Extract<MaximAPISignedURLResponse, { data: unknown }>["data"]> {
+		const response = await this.fetch<MaximAPISignedURLResponse>(
+			`/api/sdk/v1/log-repositories/attachments/upload-url?key=${encodeURIComponent(key)}&mimeType=${encodeURIComponent(mimeType)}&size=${size}`,
+		);
+		if ("error" in response) {
+			throw response.error;
+		}
+		return response.data;
+	}
+
+	private async uploadBufferToSignedUrl(url: string, data: Buffer, mimeType: string): Promise<void> {
+		const response = await this.axiosInstance.put(url, data, {
+			headers: {
+				"Content-Type": mimeType,
+				"Content-Length": data.length.toString(),
+			},
+			responseType: "text",
+			timeout: 120000,
+			transformRequest: [(body: Buffer) => body],
+			transformResponse: [(body: unknown) => body],
+			baseURL: "",
+		});
+		if (response.status >= 200 && response.status < 300) {
+			return;
+		}
+		if (response.data && typeof response.data === "object" && "error" in response.data) {
+			throw (response.data as { error: unknown }).error;
+		}
+		throw response.data;
+	}
+
+	private async readFileOrFileDataAttachment(
+		attachment: FileAttachment | FileDataAttachment,
+	): Promise<{ fileData: Buffer; mimeType: string; size: number }> {
+		const maxFileSizeBytes = 1024 * 1024 * 100;
+		if (attachment.type === "fileData") {
+			const fileData = attachment.data;
+			const mimeType = attachment.mimeType || "application/octet-stream";
+			const size = fileData.length;
+			if (size > maxFileSizeBytes) {
+				throw new Error(`File size exceeds the maximum allowed size of ${maxFileSizeBytes} bytes`);
+			}
+			return { fileData, mimeType, size };
+		}
+		if (!platform.features.fileIoSupported) {
+			throw new Error("File operations are not supported in this environment");
+		}
+		let stats;
+		try {
+			stats = await platform.fs.readFile(attachment.path);
+		} catch {
+			throw new Error(`File not found: ${attachment.path}`);
+		}
+		if (stats.data.length > maxFileSizeBytes) {
+			throw new Error(`File size exceeds the maximum allowed size of ${maxFileSizeBytes} bytes`);
+		}
+		let fileData: Buffer;
+		try {
+			fileData = Buffer.from(stats.data);
+		} catch {
+			throw new Error(`File not found: ${attachment.path}`);
+		}
+		let mimeType = attachment.mimeType || "application/octet-stream";
+		if (!mimeType || mimeType === "application/octet-stream") {
+			const source = attachment.name ?? attachment.path;
+			const inferred = platform.mime.lookup(source);
+			if (inferred) {
+				mimeType = inferred;
+			}
+		}
+		return { fileData, mimeType, size: fileData.length };
+	}
+
+	/**
+	 * Resolves a remotely fetchable URL for push payloads: URL attachments pass through;
+	 * local file / in-memory fileData attachments are uploaded via the log attachment pipeline.
+	 */
+	private async resolveAttachmentUrlForPush(attachment: Attachment, testRunId: string): Promise<string> {
+		if (attachment.type === "url") {
+			const u = (attachment as UrlAttachment).url;
+			if (!u || (!u.startsWith("http://") && !u.startsWith("https://"))) {
+				throw new Error(`Invalid URL: ${u}`);
+			}
+			return u;
+		}
+		const { fileData, mimeType, size } = await this.readFileOrFileDataAttachment(attachment);
+		const key = `test-run/${testRunId}/${attachment.id}`;
+		const { url } = await this.getLogAttachmentUploadUrl(key, mimeType, size);
+		try {
+			await this.uploadBufferToSignedUrl(url, fileData, mimeType);
+		} catch (error) {
+			const name = attachment.name ?? attachment.id;
+			throw new Error(`Failed to upload attachment ${name}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+		return url;
+	}
+
+	/**
+	 * Converts Variable format to API format for dataEntry (TEXT / JSON only).
+	 */
+	private convertNonFileVariableToAPIFormat(
 		variable: Variable,
-	): { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } {
+	): { type: "text"; payload: string } {
 		if (variable.type === VariableType.TEXT || variable.type === VariableType.JSON) {
 			return {
 				type: "text",
 				payload: variable.payload,
 			};
 		}
-
-		if (variable.type === VariableType.FILE) {
-			// Convert Attachment[] to API format
-			const files = variable.payload.map((attachment) => {
-				if (attachment.type === "url") {
-					return {
-						id: attachment.id,
-						url: attachment.url,
-						name: attachment.name,
-						type: attachment.mimeType || "application/octet-stream",
-					};
-				} else if (attachment.type === "file") {
-					// For file attachments, we need the URL - this might need to be handled differently
-					// For now, we'll use the path as URL if available
-					return {
-						id: attachment.id,
-						url: attachment.path, // Note: This might need adjustment based on how file paths are handled
-						name: attachment.name,
-						type: attachment.mimeType || "application/octet-stream",
-					};
-				} else {
-					// fileData attachments - these need special handling
-					// For now, we'll create a placeholder structure
-					return {
-						id: attachment.id,
-						url: "", // fileData attachments don't have URLs
-						name: attachment.name,
-						type: attachment.mimeType || "application/octet-stream",
-					};
-				}
-			});
-
-			return {
-				type: "file",
-				payload: {
-					files,
-				},
-			};
-		}
-
-		// Fallback (should not happen)
 		return {
 			type: "text",
 			payload: "",
@@ -291,13 +355,52 @@ export class MaximTestRunAPI extends MaximAPI {
 	}
 
 	/**
-	 * Converts dataEntry from Variable format to API format.
-	 * Handles the conversion of FILE variables to the API's expected file structure.
+	 * Converts a FILE variable to API format, uploading local/fileData attachments first.
 	 */
-	private convertDataEntryToAPIFormat(
+	private async convertFileVariableToAPIFormat(
+		variable: Extract<Variable, { type: VariableType.FILE }>,
+		testRunId: string,
+	): Promise<{ type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } }> {
+		const files = await Promise.all(
+			variable.payload.map(async (attachment) => {
+				const url = await this.resolveAttachmentUrlForPush(attachment, testRunId);
+				return {
+					id: attachment.id,
+					url,
+					name: attachment.name,
+					type: attachment.mimeType || "application/octet-stream",
+				};
+			}),
+		);
+		return {
+			type: "file",
+			payload: { files },
+		};
+	}
+
+	/**
+	 * Converts dataEntry from Variable format to API format.
+	 * FILE variables upload non-URL attachments before building the payload.
+	 */
+	private async convertDataEntryToAPIFormat(
 		dataEntry: Record<string, string | string[] | Variable | null | undefined>,
-	): Record<string, { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } | null | undefined> {
-		const result: Record<string, { type: "text"; payload: string } | { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } } | null | undefined> = {};
+		testRunId: string,
+	): Promise<
+		Record<
+			string,
+			| { type: "text"; payload: string }
+			| { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } }
+			| null
+			| undefined
+		>
+	> {
+		const result: Record<
+			string,
+			| { type: "text"; payload: string }
+			| { type: "file"; payload: { files: Array<{ id?: string; url: string; name?: string; type: string }>; text?: string } }
+			| null
+			| undefined
+		> = {};
 
 		for (const [key, value] of Object.entries(dataEntry)) {
 			if (value === null || value === undefined) {
@@ -306,14 +409,17 @@ export class MaximTestRunAPI extends MaximAPI {
 			}
 
 			if (this.isVariable(value)) {
-				result[key] = this.convertVariableToAPIFormat(value);
+				if (value.type === VariableType.FILE) {
+					result[key] = await this.convertFileVariableToAPIFormat(value, testRunId);
+				} else {
+					result[key] = this.convertNonFileVariableToAPIFormat(value);
+				}
 			} else if (typeof value === "string") {
 				result[key] = {
 					type: "text",
 					payload: value,
 				};
 			} else if (Array.isArray(value)) {
-				// Convert string array to file format
 				const files = value.map((url, index) => ({
 					id: `${key}-${index}`,
 					url: url,
@@ -362,7 +468,7 @@ export class MaximTestRunAPI extends MaximAPI {
 		const convertedEntry = entry.dataEntry
 			? {
 					...entry,
-					dataEntry: this.convertDataEntryToAPIFormat(entry.dataEntry),
+					dataEntry: await this.convertDataEntryToAPIFormat(entry.dataEntry, testRun.id),
 				}
 			: entry;
 
@@ -719,10 +825,9 @@ export class MaximTestRunAPI extends MaximAPI {
 		});
 	}
 
-	public async executeSimulationLocalPromptExecution({
+	public async executeSimulationLocalExecution({
 		testRunId,
 		workspaceId,
-		promptVersionId,
 		datasetEntryId,
 		entry,
 		simulationConfig,
@@ -731,14 +836,6 @@ export class MaximTestRunAPI extends MaximAPI {
 	}: MaximAPITestRunSimulationLocalExecutionPayload): Promise<
 		ExtractAPIDataType<MaximAPITestRunSimulationLocalExecutionPostResponse>
 	> {
-		const resolvedPersona = simulationConfig?.persona
-			? typeof simulationConfig.persona === "string"
-				? simulationConfig.persona
-				: String(
-						(entry?.dataEntry as Record<string, unknown>)?.[simulationConfig.persona.payload] ?? "",
-					)
-			: undefined;
-
 		const convertedEntry =
 			entry?.dataEntry != null
 				? {
@@ -746,15 +843,14 @@ export class MaximTestRunAPI extends MaximAPI {
 						dataEntry: this.normalizeDataEntryToVariables(
 							entry.dataEntry as Record<string, string | string[] | Variable | null | undefined>,
 						),
-						...(resolvedPersona !== undefined && { persona: resolvedPersona }),
 					}
-				: entry
-					? { ...entry, ...(resolvedPersona !== undefined && { persona: resolvedPersona }) }
-					: entry;
+				: entry;
+
+		const serializedSimulationConfig = this.serializeSimulationConfig(simulationConfig);
 
 		return new Promise((resolve, reject) => {
-			this.fetch<MaximAPITestRunSimulationLocalExecutionPostResponse>(
-				`/api/sdk/v2/test-run/simulation/prompt/local-execution`,
+			this.fetch<MaximAPITestRunSimulationLocalExecutionRawResponse>(
+				`/api/sdk/v2/test-run/simulation/local-execution`,
 				{
 					method: "POST",
 					headers: {
@@ -764,10 +860,9 @@ export class MaximTestRunAPI extends MaximAPI {
 					body: JSON.stringify({
 						testRunId,
 						workspaceId,
-						promptVersionId,
 						datasetEntryId,
 						entry: convertedEntry,
-						simulationConfig,
+						simulationConfig: serializedSimulationConfig,
 						conversationHistory,
 						testRunEntryId,
 					}),
@@ -777,7 +872,13 @@ export class MaximTestRunAPI extends MaximAPI {
 					if ("error" in response) {
 						reject(response.error);
 					} else {
-						resolve(response.data);
+						// Normalize userInput: backend returns string|null,
+						// convert to {input: string} for consumer convenience
+						const normalizedData = {
+							...response.data,
+							userInput: this.normalizeUserInput(response.data.userInput),
+						};
+						resolve(normalizedData);
 					}
 				})
 				.catch((error) => {
@@ -786,70 +887,38 @@ export class MaximTestRunAPI extends MaximAPI {
 		});
 	}
 
-	public async executeSimulationLocalWorkflowExecution({
-		testRunId,
-		workspaceId,
-		workflowId,
-		datasetEntryId,
-		entry,
-		simulationConfig,
-		conversationHistory,
-		testRunEntryId,
-	}: MaximAPITestRunSimulationLocalExecutionPayload): Promise<
-		ExtractAPIDataType<MaximAPITestRunSimulationLocalExecutionPostResponse>
-	> {
-		const resolvedPersona = simulationConfig?.persona
-			? typeof simulationConfig.persona === "string"
-				? simulationConfig.persona
-				: String(
-						(entry?.dataEntry as Record<string, unknown>)?.[simulationConfig.persona.payload] ?? "",
-					)
-			: undefined;
+	/**
+	 * Normalize userInput from backend (string|null) to Record<string, unknown>|null.
+	 * Backend returns plain string; SDK consumers expect {input: string}.
+	 */
+	private normalizeUserInput(userInput: string | null): Record<string, unknown> | null {
+		if (userInput === null || userInput === undefined) return null;
+		if (typeof userInput === "string") return { input: userInput };
+		if (typeof userInput === "object") return userInput as Record<string, unknown>;
+		return { input: String(userInput) };
+	}
 
-		const convertedEntry =
-			entry?.dataEntry != null
-				? {
-						...entry,
-						dataEntry: this.normalizeDataEntryToVariables(
-							entry.dataEntry as Record<string, string | string[] | Variable | null | undefined>,
-						),
-						...(resolvedPersona !== undefined && { persona: resolvedPersona }),
-					}
-				: entry
-					? { ...entry, ...(resolvedPersona !== undefined && { persona: resolvedPersona }) }
-					: entry;
+	/**
+	 * Serialize simulationConfig for the backend API.
+	 * Flattens customSimulator fields to top level (matching backend's flat schema).
+	 */
+	private serializeSimulationConfig(
+		config: TestRunConfig["simulationConfig"],
+	): Record<string, unknown> | undefined {
+		if (!config) return undefined;
+		const result: Record<string, unknown> = { ...config };
 
-		return new Promise((resolve, reject) => {
-			this.fetch<MaximAPITestRunSimulationLocalExecutionPostResponse>(
-				`/api/sdk/v2/test-run/simulation/workflow/local-execution`,
-				{
-					method: "POST",
-					headers: {
-						"Content-Type": "application/json",
-						Accept: "application/json",
-					},
-					body: JSON.stringify({
-						testRunId,
-						workspaceId,
-						workflowId,
-						datasetEntryId,
-						entry: convertedEntry,
-						simulationConfig,
-						conversationHistory,
-						testRunEntryId,
-					}),
-				},
-			)
-				.then((response) => {
-					if ("error" in response) {
-						reject(response.error);
-					} else {
-						resolve(response.data);
-					}
-				})
-				.catch((error) => {
-					reject(error);
-				});
-		});
+		if (config.customSimulator) {
+			result["type"] = "CUSTOM";
+			result["simulatorPrompt"] = config.customSimulator.simulatorPrompt;
+			if (config.customSimulator.model) result["model"] = config.customSimulator.model;
+			if (config.customSimulator.provider) result["provider"] = config.customSimulator.provider;
+			if (config.customSimulator.variables) result["variables"] = config.customSimulator.variables;
+			if (config.customSimulator.variableBindings) result["variableBindings"] = config.customSimulator.variableBindings;
+			if (config.customSimulator.modelParameters) result["modelParameters"] = config.customSimulator.modelParameters;
+			delete result["customSimulator"];
+		}
+
+		return result;
 	}
 }

--- a/src/lib/models/testRun.ts
+++ b/src/lib/models/testRun.ts
@@ -1,4 +1,5 @@
 import type { Data, DataStructure, DataValue, Variable } from "../models/dataset";
+import type { MaximLogger } from "../logger/logger";
 import type {
 	CombinedLocalEvaluatorType,
 	HumanEvaluationConfig,
@@ -340,6 +341,13 @@ export type TestRunConfig<T extends DataStructure | undefined = undefined> = {
 			turnNumber: number;
 		},
 	) => YieldedOutput | Promise<YieldedOutput>;
+	outputFunctionWithTracing?: (data: Data<T>, traceId: string, simulationContext?: {
+		conversationHistory: SimulationConversationTurn[];
+		currentUserInput: Record<string, unknown>;
+		turnNumber: number;
+	}) => YieldedOutput | Promise<YieldedOutput>;
+	maximLogger?: MaximLogger;
+	disableDefaultTraceCreation?: boolean;
 	promptVersion?: {
 		id: string;
 		contextToEvaluate?: string;
@@ -558,9 +566,11 @@ export type TestRunBuilder<T extends DataStructure | undefined = undefined> = {
 	 *                 },
 	 *             },
 	 *         };
-	 *     });
+	 *     }, maximLogger);
 	 */
-	yieldsOutput: (outputFunction: TestRunConfig<T>["outputFunction"]) => TestRunBuilder<T>;
+	yieldsOutput: (outputFunction: TestRunConfig<T>["outputFunction"], maximLogger?: MaximLogger) => TestRunBuilder<T>;
+
+	yieldsOutputWithTracing: (outputFunction: TestRunConfig<T>["outputFunctionWithTracing"], maximLogger: MaximLogger, disableDefaultTraceCreation?: boolean) => TestRunBuilder<T>;
 
 	/**
 	 * Sets the prompt version ID for the test run. Optionally, you can also set the context to evaluate for the prompt. (Note: setting the context to evaluate will end up overriding the CONTEXT_TO_EVALUATE dataset column value)
@@ -729,6 +739,28 @@ export type MaximAPICreateTestRunResponse =
 			};
 	  };
 
+export type MaximAPITestRunEntryCreatePayload = {
+	testRun: {
+		id: string;
+		datasetEntryId?: string;
+		datasetId?: string;
+		workspaceId: string;
+		humanEvaluationConfig?: {
+			emails: string[];
+			instructions: string;
+			requester: string;
+		};
+		evalConfig: unknown;
+		parentTestRunId?: string;
+	};
+};
+
+export type MaximAPITestRunEntryCreateResponse = {
+	data: {
+		id: string;
+	};
+};
+
 export type MaximAPITestRunEntryPushPayload<T extends DataStructure | undefined = undefined> = {
 	testRun: {
 		id: string;
@@ -765,6 +797,7 @@ export type MaximAPITestRunEntryPushPayload<T extends DataStructure | undefined 
 };
 
 export type MaximAPITestRunEntry = {
+	id?: string;
 	input?: string;
 	expectedOutput?: string;
 	contextToEvaluate?: string | string[];
@@ -774,6 +807,7 @@ export type MaximAPITestRunEntry = {
 	meta?: {
 		variables?: Record<string, Variable>;
 		sdkVariables?: Record<string, Variable>;
+		connectedTraceId?: string;
 	};
 	dataEntry: Record<string, string | string[] | Variable | null | undefined>;
 	localEvaluationResults?: (LocalEvaluationResult & { id: string })[];

--- a/src/lib/models/testRun.ts
+++ b/src/lib/models/testRun.ts
@@ -149,15 +149,47 @@ export interface TestRunLogger<T extends DataStructure | undefined = undefined> 
  */
 
 /**
+ * A single turn in the simulation conversation history.
+ * Request/response shapes depend on workflow or prompt config.
+ * - Workflow: request_fields and response_fields from workflow config
+ * - Prompt: request = { input }, response = { output, tool_calls? }
+ */
+export type SimulationConversationTurn = {
+	turn: number;
+	request: Record<string, unknown>;
+	response: Record<string, unknown>;
+	reasoning?: string;
+};
+
+/**
  * Metadata returned from simulation endpoints.
  * Contains the full simulation conversation and trace data.
  */
 export type SimulationMeta = {
+	testRunEntryId?: string;
 	sessionId?: string;
 	simulationId?: string;
 	messages: unknown[];
+	/** Last turn (user input + assistant response) for push to append to session messages */
+	lastTurn?: {
+		turn: number;
+		request: Record<string, unknown>;
+		response: Record<string, unknown>;
+	};
 	trace?: unknown[];
 	turns?: unknown[]; // For workflow simulations
+	stopReason?: string; // Reason for simulation stop from backend (e.g. from /local-execution)
+	usage?: {
+		promptTokens: number;
+		completionTokens: number;
+		totalTokens: number;
+		latency?: number;
+	};
+	cost?: {
+		input: number;
+		output: number;
+		total: number;
+	};
 };
 
 export type YieldedOutput = {
@@ -166,6 +198,10 @@ export type YieldedOutput = {
 	retrievedContextToEvaluate?: string | string[];
 	messages?: unknown[];
 	simulationMeta?: SimulationMeta;
+	/** For simulation workflow: full response shape keyed by response_fields. If omitted, { output: data } is used. */
+	simulationResponse?: Record<string, unknown>;
+	/** For simulation prompt: tool calls if assistant used tools. */
+	toolCalls?: unknown[];
 	meta?: {
 		usage?:
 			| {
@@ -296,7 +332,14 @@ export type TestRunConfig<T extends DataStructure | undefined = undefined> = {
 	data?: DataValue<T>;
 	evaluators: (LocalEvaluatorType<T> | CombinedLocalEvaluatorType<T, Record<string, PassFailCriteriaType>> | string | PlatformEvaluator)[];
 	humanEvaluationConfig?: HumanEvaluationConfig;
-	outputFunction?: (data: Data<T>) => YieldedOutput | Promise<YieldedOutput>;
+	outputFunction?: (
+		data: Data<T>,
+		simulationContext?: {
+			conversationHistory: SimulationConversationTurn[];
+			currentUserInput: Record<string, unknown>;
+			turnNumber: number;
+		},
+	) => YieldedOutput | Promise<YieldedOutput>;
 	promptVersion?: {
 		id: string;
 		contextToEvaluate?: string;
@@ -322,6 +365,11 @@ export type TestRunConfig<T extends DataStructure | undefined = undefined> = {
 		};
 		responseFields?: string[];
 		environmentId?: string;
+		stopTrigger?: {
+			field: string;
+			value: string | boolean | number;
+		};
+		additionalInstructions?: string;
 	};
 	logger?: TestRunLogger<T>;
 	concurrency?: number;
@@ -713,6 +761,7 @@ export type MaximAPITestRunEntryPushPayload<T extends DataStructure | undefined 
 		};
 	};
 	entry: MaximAPITestRunEntry;
+	localSimulation?: boolean;
 };
 
 export type MaximAPITestRunEntry = {
@@ -1022,6 +1071,55 @@ export type MaximAPITestRunEntryExecuteSimulationWorkflowResponse =
 					output: number;
 					total: number;
 				};
+			};
+	  }
+	| {
+			error: {
+				message: string;
+			};
+	  };
+
+// Local-execution API types for simulation with yieldsOutput
+export type MaximAPITestRunSimulationLocalExecutionPayload = {
+	testRunId: string;
+	workspaceId: string;
+	promptVersionId?: string;
+	workflowId?: string;
+	datasetEntryId?: string;
+	entry?: {
+		input?: string | null;
+		scenario?: string | null;
+		expectedSteps?: string | null;
+		contextToEvaluate?: string | string[] | null;
+		dataEntry?: Record<string, string | string[] | null | undefined> | null;
+		persona?: string | null;
+	};
+	simulationConfig: TestRunConfig["simulationConfig"];
+	conversationHistory?: SimulationConversationTurn[];
+	testRunEntryId?: string;
+};
+
+export type MaximAPITestRunSimulationLocalExecutionPostResponse =
+	| {
+			data: {
+				testRunEntryId: string;
+				userInput: Record<string, unknown>; // User input keyed by request_fields (workflow) or { input } (prompt)
+				turnNumber: number;
+				isComplete: boolean;
+				stopReason?: string; // Reason for simulation stop from backend
+				usage?: {
+					promptTokens: number;
+					completionTokens: number;
+					totalTokens: number;
+					latency?: number;
+				};
+				cost?: {
+					input: number;
+					output: number;
+					total: number;
+				};
+				sessionId?: string;
+				simulationId?: string;
 			};
 	  }
 	| {

--- a/src/lib/models/testRun.ts
+++ b/src/lib/models/testRun.ts
@@ -163,6 +163,18 @@ export type SimulationConversationTurn = {
 };
 
 /**
+ * Context passed to the output function during simulation turns.
+ * Provides conversation history, current user input, and cumulative usage/cost data.
+ */
+export type SimulationContext = {
+	conversationHistory: SimulationConversationTurn[];
+	currentUserInput: Record<string, unknown>;
+	turnNumber: number;
+	totalCost: number;
+	totalTokens: number;
+};
+
+/**
  * Metadata returned from simulation endpoints.
  * Contains the full simulation conversation and trace data.
  */
@@ -320,6 +332,19 @@ export type TestRunResult = {
 };
 
 /**
+ * Configuration for a custom simulator that uses a user-provided prompt
+ * instead of the default Maxim simulator.
+ */
+export type CustomSimulatorConfig = {
+	simulatorPrompt: string;
+	model: string;
+	provider: string;
+	variables?: Record<string, string>;
+	variableBindings?: Record<string, unknown>;
+	modelParameters?: Record<string, unknown>;
+};
+
+/**
  * Configuration for a test run.
  */
 export type TestRunConfig<T extends DataStructure | undefined = undefined> = {
@@ -335,17 +360,9 @@ export type TestRunConfig<T extends DataStructure | undefined = undefined> = {
 	humanEvaluationConfig?: HumanEvaluationConfig;
 	outputFunction?: (
 		data: Data<T>,
-		simulationContext?: {
-			conversationHistory: SimulationConversationTurn[];
-			currentUserInput: Record<string, unknown>;
-			turnNumber: number;
-		},
+		simulationContext?: SimulationContext,
 	) => YieldedOutput | Promise<YieldedOutput>;
-	outputFunctionWithTracing?: (data: Data<T>, traceId: string, simulationContext?: {
-		conversationHistory: SimulationConversationTurn[];
-		currentUserInput: Record<string, unknown>;
-		turnNumber: number;
-	}) => YieldedOutput | Promise<YieldedOutput>;
+	outputFunctionWithTracing?: (data: Data<T>, traceId: string, simulationContext?: SimulationContext) => YieldedOutput | Promise<YieldedOutput>;
 	maximLogger?: MaximLogger;
 	disableDefaultTraceCreation?: boolean;
 	promptVersion?: {
@@ -378,6 +395,7 @@ export type TestRunConfig<T extends DataStructure | undefined = undefined> = {
 			value: string | boolean | number;
 		};
 		additionalInstructions?: string;
+		customSimulator?: CustomSimulatorConfig;
 	};
 	logger?: TestRunLogger<T>;
 	concurrency?: number;
@@ -1117,8 +1135,6 @@ export type MaximAPITestRunEntryExecuteSimulationWorkflowResponse =
 export type MaximAPITestRunSimulationLocalExecutionPayload = {
 	testRunId: string;
 	workspaceId: string;
-	promptVersionId?: string;
-	workflowId?: string;
 	datasetEntryId?: string;
 	entry?: {
 		input?: string | null;
@@ -1126,21 +1142,47 @@ export type MaximAPITestRunSimulationLocalExecutionPayload = {
 		expectedSteps?: string | null;
 		contextToEvaluate?: string | string[] | null;
 		dataEntry?: Record<string, string | string[] | null | undefined> | null;
-		persona?: string | null;
 	};
 	simulationConfig: TestRunConfig["simulationConfig"];
 	conversationHistory?: SimulationConversationTurn[];
 	testRunEntryId?: string;
 };
 
+// Raw response from the backend (before normalization)
+export type MaximAPITestRunSimulationLocalExecutionRawResponse =
+	| {
+			data: {
+				testRunEntryId?: string;
+				userInput: string | null;
+				stopReason?: "STOP_PHRASE" | "MAX_TURNS" | null;
+				usage?: {
+					promptTokens: number;
+					completionTokens: number;
+					totalTokens: number;
+					latency?: number;
+				};
+				cost?: {
+					input: number;
+					output: number;
+					total: number;
+				};
+				sessionId?: string;
+				simulationId?: string;
+			};
+	  }
+	| {
+			error: {
+				message: string;
+			};
+	  };
+
+// Normalized response after SDK processing (userInput converted to object)
 export type MaximAPITestRunSimulationLocalExecutionPostResponse =
 	| {
 			data: {
-				testRunEntryId: string;
-				userInput: Record<string, unknown>; // User input keyed by request_fields (workflow) or { input } (prompt)
-				turnNumber: number;
-				isComplete: boolean;
-				stopReason?: string; // Reason for simulation stop from backend
+				testRunEntryId?: string;
+				userInput: Record<string, unknown> | null;
+				stopReason?: "STOP_PHRASE" | "MAX_TURNS" | null;
 				usage?: {
 					promptTokens: number;
 					completionTokens: number;

--- a/src/lib/testRun/runUtils.ts
+++ b/src/lib/testRun/runUtils.ts
@@ -26,6 +26,21 @@ export async function runOutputFunction<T extends DataStructure | undefined>(
 	}
 }
 
+export async function runOutputFunctionWithTracing<T extends DataStructure | undefined>(
+	outputFunction: NonNullable<TestRunConfig<T>["outputFunctionWithTracing"]>,
+	dataEntry: Data<T>,
+	traceId: string,
+): Promise<ReturnType<NonNullable<TestRunConfig<T>["outputFunctionWithTracing"]>>> {
+	try {
+		const result = await outputFunction(dataEntry, traceId);
+		return result;
+	} catch (err) {
+		throw new Error(`Error while running output function`, {
+			cause: err,
+		});
+	}
+}
+
 /**
  * Runs local evaluations on the data entry.
  * @param evaluators - The evaluators to run

--- a/src/lib/testRun/runUtils.ts
+++ b/src/lib/testRun/runUtils.ts
@@ -7,7 +7,7 @@ import type {
 	PassFailCriteriaType,
 	Result,
 } from "../models/evaluator";
-import type { TestRunConfig, TestRunLogger, YieldedOutput } from "../models/testRun";
+import type { SimulationConversationTurn, TestRunConfig, TestRunLogger, YieldedOutput } from "../models/testRun";
 import { ExtractAPIDataType } from "../utils/utils";
 import type { MaximAPITestRunEntryExecuteSimulationPromptGetResponse } from "../models/testRun";
 import type { MaximAPITestRunEntryExecuteSimulationWorkflowGetResponse } from "../models/testRun";
@@ -512,4 +512,263 @@ export function simulationWorkflowIdOutputFunctionClosure<T extends DataStructur
 			throw error;
 		}
 	};
+}
+
+export function simulationYieldsOutputFunctionClosure<T extends DataStructure | undefined>(
+	testRunId: string,
+	workspaceId: string,
+	simulationConfig: NonNullable<TestRunConfig<T>["simulationConfig"]>,
+	outputFunction: NonNullable<TestRunConfig<T>["outputFunction"]>,
+	TestRunAPIService: MaximTestRunAPI,
+	entityType: "prompt" | "workflow",
+	promptVersionId: string | undefined,
+	workflowId: string | undefined,
+	datasetEntryId: string | undefined,
+	input: string | undefined,
+	scenario: string | undefined,
+	expectedSteps: string | undefined,
+	contextToEvaluate: string | string[] | undefined,
+	timeoutInMinutes: number = 15,
+	logger: { info: (message: string) => void },
+) {
+		return async (data: Data<T>): Promise<YieldedOutput> => {
+		let testRunEntryId: string | undefined;
+		try {
+			const maxTurns = simulationConfig.maxTurns ?? 10;
+			const conversationHistory: SimulationConversationTurn[] = [];
+			const simulationOutputs: string[] = [];
+			let sessionId: string | undefined;
+			let simulationId: string | undefined;
+			let stopReason: string | undefined;
+			let isComplete = false;
+			let turnNumber = 0;
+
+			// Aggregated usage and cost
+			let totalPromptTokens = 0;
+			let totalCompletionTokens = 0;
+			let totalTokens = 0;
+			let totalInputCost = 0;
+			let totalOutputCost = 0;
+			let totalCost = 0;
+
+			// Resolve persona with priority: dataset column > simulation config
+			let datasetPersona: string | undefined;
+			if (data && typeof data === "object") {
+				for (const [key, value] of Object.entries(data)) {
+					if (key.toLowerCase() === "persona" && value != null) {
+						const personaStr = String(value).trim();
+						if (personaStr) {
+							datasetPersona = personaStr;
+							break;
+						}
+					}
+				}
+			}
+			let simconfigPersona: string | undefined;
+			if (simulationConfig.persona && !datasetPersona) {
+				if (typeof simulationConfig.persona === "string") {
+					simconfigPersona = simulationConfig.persona;
+				} else if (simulationConfig.persona.type === "DATASET_COLUMN") {
+					const colName = simulationConfig.persona.payload;
+					const val = data && typeof data === "object" ? data[colName] : undefined;
+					if (val != null) {
+						const valStr = String(val).trim();
+						simconfigPersona = valStr || undefined;
+					}
+				}
+			}
+
+			const resolvedPersona = datasetPersona ?? simconfigPersona ;
+			const resolvedSimulationConfig = { ...simulationConfig, persona: resolvedPersona };
+
+			// Turn-by-turn simulation loop
+			const simulationStartTime = Date.now();
+			while (turnNumber < maxTurns && !isComplete) {
+				turnNumber++;
+
+				// Call the local-execution endpoint to get the next user message
+				let turnResult;
+				if (entityType === "prompt") {
+					turnResult = await TestRunAPIService.executeSimulationLocalPromptExecution({
+						testRunId,
+						workspaceId,
+						promptVersionId,
+						datasetEntryId,
+						entry:
+							turnNumber === 1
+								? {
+										input: input ?? null,
+										scenario: scenario ?? null,
+										expectedSteps: expectedSteps ?? null,
+										contextToEvaluate: contextToEvaluate ?? null,
+										dataEntry: data,
+									}
+								: undefined,
+						simulationConfig: resolvedSimulationConfig,
+						conversationHistory: turnNumber > 1 ? conversationHistory : undefined,
+						testRunEntryId,
+					});
+				} else if (entityType === "workflow") {
+					turnResult = await TestRunAPIService.executeSimulationLocalWorkflowExecution({
+						testRunId,
+						workspaceId,
+						workflowId,
+						datasetEntryId,
+						entry:
+							turnNumber === 1
+								? {
+										input: input ?? null,
+										scenario: scenario ?? null,
+										expectedSteps: expectedSteps ?? null,
+										contextToEvaluate: contextToEvaluate ?? null,
+										dataEntry: data,
+									}
+								: undefined,
+						simulationConfig: resolvedSimulationConfig,
+						conversationHistory: turnNumber > 1 ? conversationHistory : undefined,
+						testRunEntryId,
+					});
+				} else {
+					throw new Error(`Invalid entity type: ${entityType}`);
+				}
+
+				// Store testRunEntryId, sessionId, simulationId from first turn
+				if (turnNumber === 1) {
+					testRunEntryId = turnResult.testRunEntryId;
+					sessionId = turnResult.sessionId;
+					simulationId = turnResult.simulationId;
+				}
+
+				// Aggregate usage and cost
+				if (turnResult.usage) {
+					totalPromptTokens += turnResult.usage.promptTokens;
+					totalCompletionTokens += turnResult.usage.completionTokens;
+					totalTokens += turnResult.usage.totalTokens;
+				}
+				if (turnResult.cost) {
+					totalInputCost += turnResult.cost.input;
+					totalOutputCost += turnResult.cost.output;
+					totalCost += turnResult.cost.total;
+				}
+
+				// Check stopReason from backend (triggers end of simulation, log the reason)
+				if (turnResult.stopReason) {
+					stopReason = turnResult.stopReason;
+					logger.info(`Simulation stopped: ${stopReason}`);
+					isComplete = true;
+					break;
+				}
+
+				// Check if simulation is complete from backend
+				if (turnResult.isComplete) {
+					isComplete = true;
+					break;
+				}
+
+				const userInput = turnResult.userInput;
+
+				// Call the user's outputFunction with simulation context
+				const assistantOutput = await outputFunction(data, {
+					conversationHistory,
+					currentUserInput: userInput,
+					turnNumber,
+				});
+
+				// Build response: Prompt = { output, tool_calls? }, Workflow = simulationResponse ?? { output }
+				const response: Record<string, unknown> =
+					entityType === "prompt"
+						? {
+								output: assistantOutput.data,
+								tool_calls: assistantOutput.toolCalls ?? [],
+							}
+						: assistantOutput.simulationResponse ?? { output: assistantOutput.data };
+
+				simulationOutputs.push(assistantOutput.data);
+
+				// Add turn to conversation history for next API call
+				const normalizedRequest: Record<string, unknown> =
+					entityType === "prompt"
+						? { input: userInput ?? "" }
+						: typeof userInput === "object" && userInput !== null
+							? userInput
+							: { input: String(userInput ?? "") };
+				conversationHistory.push({
+					turn: turnNumber,
+					request: normalizedRequest,
+					response,
+				});
+
+				// Check stopTrigger
+				if (simulationConfig.stopTrigger) {
+					const fieldValue = getNestedFieldValue(assistantOutput, simulationConfig.stopTrigger.field);
+					if (fieldValue === simulationConfig.stopTrigger.value) {
+						isComplete = true;
+						break;
+					}
+				}
+			}
+
+			// Build final YieldedOutput - usage/cost in simulationMeta for simulation runs
+			const totalLatency = Date.now() - simulationStartTime;
+			const lastTurn =
+				conversationHistory.length > 0
+					? {
+							turn: conversationHistory.length,
+							request: conversationHistory[conversationHistory.length - 1].request,
+							response: conversationHistory[conversationHistory.length - 1].response,
+						}
+					: undefined;
+
+			const finalOutput: YieldedOutput = {
+				data: simulationOutputs[simulationOutputs.length - 1] || "",
+				simulationOutputs,
+				simulationMeta: {
+					testRunEntryId,
+					sessionId,
+					simulationId,
+					messages: conversationHistory,
+					lastTurn,
+					...(stopReason && { stopReason }),
+					usage: {
+						promptTokens: totalPromptTokens,
+						completionTokens: totalCompletionTokens,
+						totalTokens: totalTokens,
+						latency: totalLatency,
+					},
+					cost: {
+						input: totalInputCost,
+						output: totalOutputCost,
+						total: totalCost,
+					},
+				},
+			};
+
+			return finalOutput;
+		} catch (error) {
+			if (testRunEntryId) {
+				try {
+					await TestRunAPIService.updateSimulationStatus(testRunEntryId, "FAILED");
+				} catch (cleanupError) {
+					// Log but don't mask the original error
+					const msg = `Failed to mark simulation as failed (testRunEntryId: ${testRunEntryId}): ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`;
+					"error" in logger && typeof logger.error === "function" ? logger.error(msg) : logger.info(msg);
+				}
+			}
+			throw error;
+		}
+	};
+}
+
+// Helper function to get nested field value from an object
+function getNestedFieldValue(obj: any, fieldPath: string): any {
+	const keys = fieldPath.split(".");
+	let value = obj;
+	for (const key of keys) {
+		if (value && typeof value === "object" && key in value) {
+			value = value[key];
+		} else {
+			return undefined;
+		}
+	}
+	return value;
 }

--- a/src/lib/testRun/runUtils.ts
+++ b/src/lib/testRun/runUtils.ts
@@ -406,6 +406,7 @@ export function simulationPromptVersionIdOutputFunctionClosure<T extends DataStr
 							retrievedContextToEvaluate: undefined,
 							messages: result.messages,
 							simulationMeta: {
+								testRunEntryId: postResult.testRunEntryId,
 								sessionId: result.sessionId,
 								simulationId: result.simulationId,
 								messages: result.messages ?? [],
@@ -422,6 +423,7 @@ export function simulationPromptVersionIdOutputFunctionClosure<T extends DataStr
 							retrievedContextToEvaluate: undefined,
 							messages: result.messages,
 							simulationMeta: {
+								testRunEntryId: postResult.testRunEntryId,
 								sessionId: result.sessionId,
 								simulationId: result.simulationId,
 								messages: result.messages ?? [],
@@ -489,6 +491,7 @@ export function simulationWorkflowIdOutputFunctionClosure<T extends DataStructur
 							retrievedContextToEvaluate: undefined,
 							messages: undefined,
 							simulationMeta: {
+								testRunEntryId: postResult.testRunEntryId,
 								sessionId: result.sessionId,
 								simulationId: result.simulationId,
 								messages: [],
@@ -508,6 +511,7 @@ export function simulationWorkflowIdOutputFunctionClosure<T extends DataStructur
 							retrievedContextToEvaluate: undefined,
 							messages: undefined,
 							simulationMeta: {
+								testRunEntryId: postResult.testRunEntryId,
 								sessionId: result.sessionId,
 								simulationId: result.simulationId,
 								messages: [],
@@ -535,9 +539,6 @@ export function simulationYieldsOutputFunctionClosure<T extends DataStructure | 
 	simulationConfig: NonNullable<TestRunConfig<T>["simulationConfig"]>,
 	outputFunction: NonNullable<TestRunConfig<T>["outputFunction"]>,
 	TestRunAPIService: MaximTestRunAPI,
-	entityType: "prompt" | "workflow",
-	promptVersionId: string | undefined,
-	workflowId: string | undefined,
 	datasetEntryId: string | undefined,
 	input: string | undefined,
 	scenario: string | undefined,
@@ -593,7 +594,7 @@ export function simulationYieldsOutputFunctionClosure<T extends DataStructure | 
 				}
 			}
 
-			const resolvedPersona = datasetPersona ?? simconfigPersona ;
+			const resolvedPersona = datasetPersona ?? simconfigPersona;
 			const resolvedSimulationConfig = { ...simulationConfig, persona: resolvedPersona };
 
 			// Turn-by-turn simulation loop
@@ -602,50 +603,24 @@ export function simulationYieldsOutputFunctionClosure<T extends DataStructure | 
 				turnNumber++;
 
 				// Call the local-execution endpoint to get the next user message
-				let turnResult;
-				if (entityType === "prompt") {
-					turnResult = await TestRunAPIService.executeSimulationLocalPromptExecution({
-						testRunId,
-						workspaceId,
-						promptVersionId,
-						datasetEntryId,
-						entry:
-							turnNumber === 1
-								? {
-										input: input ?? null,
-										scenario: scenario ?? null,
-										expectedSteps: expectedSteps ?? null,
-										contextToEvaluate: contextToEvaluate ?? null,
-										dataEntry: data,
-									}
-								: undefined,
-						simulationConfig: resolvedSimulationConfig,
-						conversationHistory: turnNumber > 1 ? conversationHistory : undefined,
-						testRunEntryId,
-					});
-				} else if (entityType === "workflow") {
-					turnResult = await TestRunAPIService.executeSimulationLocalWorkflowExecution({
-						testRunId,
-						workspaceId,
-						workflowId,
-						datasetEntryId,
-						entry:
-							turnNumber === 1
-								? {
-										input: input ?? null,
-										scenario: scenario ?? null,
-										expectedSteps: expectedSteps ?? null,
-										contextToEvaluate: contextToEvaluate ?? null,
-										dataEntry: data,
-									}
-								: undefined,
-						simulationConfig: resolvedSimulationConfig,
-						conversationHistory: turnNumber > 1 ? conversationHistory : undefined,
-						testRunEntryId,
-					});
-				} else {
-					throw new Error(`Invalid entity type: ${entityType}`);
-				}
+				const turnResult = await TestRunAPIService.executeSimulationLocalExecution({
+					testRunId,
+					workspaceId,
+					datasetEntryId: turnNumber === 1 ? datasetEntryId : undefined,
+					entry:
+						turnNumber === 1
+							? {
+									input: input ?? null,
+									scenario: scenario ?? null,
+									expectedSteps: expectedSteps ?? null,
+									contextToEvaluate: contextToEvaluate ?? null,
+									dataEntry: data,
+								}
+							: undefined,
+					simulationConfig: resolvedSimulationConfig,
+					conversationHistory: turnNumber > 1 ? conversationHistory : undefined,
+					testRunEntryId,
+				});
 
 				// Store testRunEntryId, sessionId, simulationId from first turn
 				if (turnNumber === 1) {
@@ -674,39 +649,38 @@ export function simulationYieldsOutputFunctionClosure<T extends DataStructure | 
 					break;
 				}
 
-				// Check if simulation is complete from backend
-				if (turnResult.isComplete) {
+				// userInput is normalized to Record<string, unknown>|null by the API layer
+				const userInput = turnResult.userInput;
+
+				// If userInput is null/undefined, simulation has ended
+				if (userInput === null || userInput === undefined) {
 					isComplete = true;
 					break;
 				}
-
-				const userInput = turnResult.userInput;
 
 				// Call the user's outputFunction with simulation context
 				const assistantOutput = await outputFunction(data, {
 					conversationHistory,
 					currentUserInput: userInput,
 					turnNumber,
+					totalCost,
+					totalTokens,
 				});
 
-				// Build response: Prompt = { output, tool_calls? }, Workflow = simulationResponse ?? { output }
-				const response: Record<string, unknown> =
-					entityType === "prompt"
-						? {
-								output: assistantOutput.data,
-								tool_calls: assistantOutput.toolCalls ?? [],
-							}
-						: assistantOutput.simulationResponse ?? { output: assistantOutput.data };
+				// Build response for conversation history
+				const response: Record<string, unknown> = {
+					output: assistantOutput.data,
+					tool_calls: assistantOutput.toolCalls ?? [],
+				};
 
 				simulationOutputs.push(assistantOutput.data);
 
 				// Add turn to conversation history for next API call
-				const normalizedRequest: Record<string, unknown> =
-					entityType === "prompt"
-						? { input: userInput ?? "" }
-						: typeof userInput === "object" && userInput !== null
-							? userInput
-							: { input: String(userInput ?? "") };
+				const normalizedRequest: Record<string, unknown> = {
+					input: typeof userInput === "object" && userInput !== null
+						? ((userInput as Record<string, unknown>)["input"] ?? "")
+						: String(userInput ?? ""),
+				};
 				conversationHistory.push({
 					turn: turnNumber,
 					request: normalizedRequest,

--- a/src/lib/testRun/testRun.ts
+++ b/src/lib/testRun/testRun.ts
@@ -103,11 +103,8 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 		const hasOutputFunctionWithTracing = !!config.outputFunctionWithTracing;
 		const outputSourceCount = (hasOutputFunction ? 1 : 0) + (hasOutputFunctionWithTracing ? 1 : 0) + (hasPromptVersion ? 1 : 0) + (hasPromptChainVersion ? 1 : 0) + (hasWorkflow ? 1 : 0);
 
-		// Simulation + yieldsOutput: requires outputFunction + (promptVersion OR workflow)
+		// Simulation + yieldsOutput: local-execution mode (no prompt/workflow ID required)
 		if (config.simulationConfig && hasOutputFunction) {
-			if (!hasPromptVersion && !hasWorkflow) {
-				errors.push("Simulation config with yieldsOutput requires either withPromptVersionId or withWorkflowId to be set.");
-			}
 			if (hasPromptChainVersion) {
 				errors.push("Simulation config with yieldsOutput cannot use withPromptChainVersionId. Use withPromptVersionId or withWorkflowId.");
 			}
@@ -128,7 +125,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				errors.push("Simulation config cannot be used with withPromptChainVersionId. Use withWorkflowId, withPromptVersionId, or yieldsOutput instead.");
 			}
 			if (!config.workflow && !config.promptVersion && !config.outputFunction) {
-				errors.push("Simulation config requires either withWorkflowId, withPromptVersionId, yieldsOutput to be set.");
+				errors.push("Simulation config requires either withWorkflowId, withPromptVersionId, or yieldsOutput to be set.");
 			}
 			if (config.simulationConfig.responseFields && config.simulationConfig.responseFields.length > 0 && !config.workflow) {
 				errors.push("responseFields in simulationConfig can only be used with withWorkflowId, not with withPromptVersionId, yieldsOutput or yieldsOutputWithTracing.");
@@ -233,13 +230,8 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 
 			// 2. get the output
 			if(config.simulationConfig && outputFunction) {
-				// Determine entity type (prompt or workflow)
-				const entityType = workflow ? "workflow" : "prompt";
-				const promptVersionId = promptVersion?.id;
-				const workflowIdForSim = workflow?.id;
-
 				let contextToEvaluateForSimulation = contextToEvaluate ?? promptVersion?.contextToEvaluate ?? workflow?.contextToEvaluate;
-				
+
 				// Build the simulation closure
 				const outputFunctionToExecute = simulationYieldsOutputFunctionClosure<T>(
 					testRun.id,
@@ -247,9 +239,6 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 					config.simulationConfig,
 					outputFunction,
 					APITestRunService,
-					entityType,
-					promptVersionId,
-					workflowIdForSim,
 					row.id,
 					input,
 					scenario,
@@ -426,7 +415,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 
 				return;
 			} // Make sure if its local workflow or remote workflow
-			else if (outputFunction || outputFunctionWithTracing || evaluators.filter((e) => typeof e !== "string").length > 0) {
+			else if (outputFunction || outputFunctionWithTracing || evaluators.filter((e) => typeof e !== "string").length > 0     || (config.simulationConfig && (workflow || promptVersion))) {
 			// Make sure if its local workflow or remote workflow
 				let outputFunctionToExecute: NonNullable<TestRunConfig<T>["outputFunction"]> | undefined;
 				let outputFunctionWithTracingToExecute: NonNullable<TestRunConfig<T>["outputFunctionWithTracing"]> | undefined;
@@ -436,13 +425,9 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				} else if (outputFunctionWithTracing) {
 					outputFunctionWithTracingToExecute = outputFunctionWithTracing;
 				} else {
-					// Check if we need to use simulation endpoints (simulationConfig + local evaluators)
-					const hasLocalEvaluators =
-						evaluators.filter((e) => typeof e !== "string" && "evaluationFunction" in e).length > 0;
-					const useSimulationEndpoints = config.simulationConfig && hasLocalEvaluators;
 
 					if (workflow) {
-						if (useSimulationEndpoints) {
+						if (config.simulationConfig) {
 							const contextToEvaluateForSimulation = contextToEvaluate ?? workflow.contextToEvaluate;
 							outputFunctionToExecute = simulationWorkflowIdOutputFunctionClosure<T>(
 								testRun.id,
@@ -465,7 +450,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 							);
 						}
 					} else if (promptVersion) {
-						if (useSimulationEndpoints) {
+						if (config.simulationConfig) {
 							// Use contextToEvaluate from row data, or fallback to promptVersion.contextToEvaluate
 							const contextToEvaluateForSimulation = contextToEvaluate ?? promptVersion.contextToEvaluate;
 							outputFunctionToExecute = simulationPromptVersionIdOutputFunctionClosure<T>(
@@ -503,12 +488,17 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 					}
 				}
 
-				const testRunEntry = await APITestRunService.createTestRunEntry({
-					testRun: { ...testRun, datasetId, datasetEntryId: row.id },
-				});
+				// When using simulation endpoints, the backend creates the entry via the simulation API —
+				// do NOT create one separately (matches Python: create_test_run_entry only when simulation_config is None)
+				let testRunEntry: { id: string } | undefined;
+				if (!config.simulationConfig) {
+					testRunEntry = await APITestRunService.createTestRunEntry({
+						testRun: { ...testRun, datasetId, datasetEntryId: row.id },
+					});
+				}
 
 				const traceId = uuidv4();
-				if (!config.disableDefaultTraceCreation && internalMaximLogger) {
+				if (!config.disableDefaultTraceCreation && internalMaximLogger && testRunEntry) {
 					try {
 						const testRunEntryTrace = internalMaximLogger.trace({
 							id: traceId,
@@ -637,72 +627,95 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 					}
 				}
 
-				try {
-				await APITestRunService.pushTestRunEntry({
-					testRun: { ...testRun, datasetId, datasetEntryId: row.id },
-					runConfig: output.meta
-						? {
-							cost: output.meta.cost,
-							usage: output.meta.usage
-								? "completionTokens" in output.meta.usage
-									? {
-										completion_tokens: output.meta.usage.completionTokens,
-										prompt_tokens: output.meta.usage.promptTokens,
-										total_tokens: output.meta.usage.totalTokens,
-										latency: output.meta.usage.latency,
-									}
-									: {
-										latency: output.meta.usage.latency,
-									}
-								: undefined,
-						}
-						: undefined,
-					entry: {
-						id: testRunEntry.id,
-						input,
-						output: output.data,
-						meta: {
-							sdkVariables:
-								evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
-									? Object.entries(evaluatorOutputOverrides).reduce(
-										(acc, [id, val]) => {
-											acc[id] = {
-												type: VariableType.JSON,
-												payload: JSON.stringify(val),
-											};
-											return acc;
-										},
-										{} as Record<string, Variable>,
-									)
-									: undefined,
-							connectedTraceId: internalMaximLogger ? traceId : undefined,
-						},
-						expectedOutput,
-						contextToEvaluate,
-						scenario,
-						expectedSteps,
-						dataEntry: row.data,
-						localEvaluationResults: localEvaluationResults
-							? localEvaluationResults.map((result) => ({
-								...result,
-								id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
-							}))
-							: undefined,
-						simulationMeta: output.simulationMeta,
-					},
-				});
-					
-				} catch (pushError) {
-					const testRunEntryId = output?.simulationMeta?.testRunEntryId;
-					if (testRunEntryId) {
-						try {
-							await APITestRunService.updateSimulationStatus(testRunEntryId, "FAILED");
-						} catch (cleanupError) {
-							const msg = `Failed to mark simulation as failed after push error (testRunEntryId: ${testRunEntryId}): ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`;
-							"error" in logger && typeof logger.error === "function" ? logger.error(msg) : logger.info(msg);
+				// For simulation endpoint entries, the backend already ran full simulation + evaluation.
+				// Only push if we have local eval results to send; skip otherwise to avoid double evaluation.
+				const isSimulationEndpointEntry = !!config.simulationConfig && !outputFunction && !outputFunctionWithTracing;
+				const hasLocalEvalResults = localEvaluationResults && localEvaluationResults.length > 0;
+				const shouldPush = !isSimulationEndpointEntry || hasLocalEvalResults;
+
+				if (shouldPush) {
+					// For simulation endpoint entries with local results: filter evalConfig to only
+					// local evaluators so the V4 push fast path marks COMPLETE without re-queuing
+					// for platform evals (which the simulation worker already ran).
+					const pushTestRun: Record<string, unknown> = { ...testRun, datasetId, datasetEntryId: row.id };
+					if (isSimulationEndpointEntry) {
+						const ec = pushTestRun["evalConfig"] as Record<string, unknown> | undefined;
+						if (ec && Array.isArray(ec["evals"])) {
+							pushTestRun["evalConfig"] = {
+								...ec,
+								evals: (ec["evals"] as Array<Record<string, unknown>>).filter(
+									(e) => e["type"] === "Local",
+								),
+							};
 						}
 					}
-					throw pushError;
+
+					try {
+						await APITestRunService.pushTestRunEntry({
+							testRun: pushTestRun as typeof testRun & { datasetId?: string; datasetEntryId?: string },
+							runConfig: output.meta
+								? {
+									cost: output.meta.cost,
+									usage: output.meta.usage
+										? "completionTokens" in output.meta.usage
+											? {
+												completion_tokens: output.meta.usage.completionTokens,
+												prompt_tokens: output.meta.usage.promptTokens,
+												total_tokens: output.meta.usage.totalTokens,
+												latency: output.meta.usage.latency,
+											}
+											: {
+												latency: output.meta.usage.latency,
+											}
+										: undefined,
+								}
+								: undefined,
+							entry: {
+								id: testRunEntry?.id,
+								input,
+								output: output.data,
+								meta: {
+									sdkVariables:
+										evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
+											? Object.entries(evaluatorOutputOverrides).reduce(
+												(acc, [id, val]) => {
+													acc[id] = {
+														type: VariableType.JSON,
+														payload: JSON.stringify(val),
+													};
+													return acc;
+												},
+												{} as Record<string, Variable>,
+											)
+											: undefined,
+									connectedTraceId: internalMaximLogger ? traceId : undefined,
+								},
+								expectedOutput,
+								contextToEvaluate,
+								scenario,
+								expectedSteps,
+								dataEntry: row.data,
+								localEvaluationResults: localEvaluationResults
+									? localEvaluationResults.map((result) => ({
+										...result,
+										id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
+									}))
+									: undefined,
+								simulationMeta: output.simulationMeta,
+							},
+						});
+					} catch (pushError) {
+						const testRunEntryId = output?.simulationMeta?.testRunEntryId;
+						if (testRunEntryId) {
+							try {
+								await APITestRunService.updateSimulationStatus(testRunEntryId, "FAILED");
+							} catch (cleanupError) {
+								const msg = `Failed to mark simulation as failed after push error (testRunEntryId: ${testRunEntryId}): ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`;
+								"error" in logger && typeof logger.error === "function" ? logger.error(msg) : logger.info(msg);
+							}
+						}
+						throw pushError;
+					}
 				}
 
 				// 5. log the test run entry with local evaluation results
@@ -789,12 +802,15 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 
 			const tagsEnrichedWithRepoId = config.maximLogger ? [...(tags ?? []), `repoId:${config.maximLogger.id}`] : tags;
 
+			const hasLocalEvaluators = evaluators.filter((e) => typeof e !== "string" && "evaluationFunction" in e).length > 0;
+			const requiresLocalRun = hasLocalEvaluators || !!config.outputFunction || !!config.outputFunctionWithTracing;
+
 			const testRun = await APITestRunService.createTestRun(
 				name,
 				workspaceId,
 				"SINGLE",
 				evalConfig,
-				evaluators.filter((e) => typeof e !== "string" && "evaluationFunction" in e).length > 0 ? true : false,
+				requiresLocalRun,
 				workflow?.id,
 				promptVersion?.id,
 				promptChainVersion?.id,

--- a/src/lib/testRun/testRun.ts
+++ b/src/lib/testRun/testRun.ts
@@ -26,6 +26,7 @@ import {
 	runOutputFunction,
 	simulationPromptVersionIdOutputFunctionClosure,
 	simulationWorkflowIdOutputFunctionClosure,
+	simulationYieldsOutputFunctionClosure,
 	workflowIdOutputFunctionClosure,
 } from "./runUtils";
 import { sanitizeData, sanitizeEvaluators } from "./sanitizationUtils";
@@ -84,27 +85,38 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				"Output function or prompt version id, prompt chain version id, or workflow id is required to run a test. You can use either yieldsOutput, withPromptVersionId, withPromptChainVersionId or withWorkflowId to set them respectively.",
 			);
 		}
-		if (
-			(config.outputFunction ? 1 : 0) + (config.promptVersion ? 1 : 0) + (config.promptChainVersion ? 1 : 0) + (config.workflow ? 1 : 0) !==
-			1
-		) {
+		const hasOutputFunction = !!config.outputFunction;
+		const hasPromptVersion = !!config.promptVersion;
+		const hasPromptChainVersion = !!config.promptChainVersion;
+		const hasWorkflow = !!config.workflow;
+		const outputSourceCount = (hasOutputFunction ? 1 : 0) + (hasPromptVersion ? 1 : 0) + (hasPromptChainVersion ? 1 : 0) + (hasWorkflow ? 1 : 0);
+
+		// Simulation + yieldsOutput: requires outputFunction + (promptVersion OR workflow)
+		if (config.simulationConfig && hasOutputFunction) {
+			if (!hasPromptVersion && !hasWorkflow) {
+				errors.push("Simulation config with yieldsOutput requires either withPromptVersionId or withWorkflowId to be set.");
+			}
+			if (hasPromptChainVersion) {
+				errors.push("Simulation config with yieldsOutput cannot use withPromptChainVersionId. Use withPromptVersionId or withWorkflowId.");
+			}
+			if (hasPromptVersion && hasWorkflow) {
+				errors.push("Simulation config with yieldsOutput cannot use both withPromptVersionId and withWorkflowId. Set exactly one.");
+			}
+		} else if (outputSourceCount !== 1) {
 			errors.push("Exactly one of outputFunction, promptVersionId, promptChainVersionId, or workflowId must be set.");
 		}
 		if (!config.data) {
 			errors.push("Data or dataset id is required to run a test.");
 		}
 		if (config.simulationConfig) {
-			if (config.outputFunction) {
-				errors.push("Simulation config cannot be used with yieldsOutput. Use withWorkflowId or withPromptVersionId instead.");
-			}
 			if (config.promptChainVersion) {
-				errors.push("Simulation config cannot be used with withPromptChainVersionId. Use withWorkflowId or withPromptVersionId instead.");
+				errors.push("Simulation config cannot be used with withPromptChainVersionId. Use withWorkflowId, withPromptVersionId, or yieldsOutput instead.");
 			}
-			if (!config.workflow && !config.promptVersion) {
-				errors.push("Simulation config requires either withWorkflowId or withPromptVersionId to be set.");
+			if (!config.workflow && !config.promptVersion && !config.outputFunction) {
+				errors.push("Simulation config requires either withWorkflowId, withPromptVersionId, or yieldsOutput to be set.");
 			}
 			if (config.simulationConfig.responseFields && config.simulationConfig.responseFields.length > 0 && !config.workflow) {
-				errors.push("responseFields in simulationConfig can only be used with withWorkflowId, not with withPromptVersionId.");
+				errors.push("responseFields in simulationConfig can only be used with withWorkflowId, not with withPromptVersionId or yieldsOutput.");
 			}
 		}
 
@@ -203,12 +215,206 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				: undefined;
 
 			// 2. get the output
-			// Make sure if its local workflow or remote workflow
-			if (outputFunction || evaluators.filter((e) => typeof e !== "string").length > 0) {
+			if(config.simulationConfig && outputFunction) {
+				// Determine entity type (prompt or workflow)
+				const entityType = workflow ? "workflow" : "prompt";
+				const promptVersionId = promptVersion?.id;
+				const workflowIdForSim = workflow?.id;
+
+				let contextToEvaluateForSimulation = contextToEvaluate ?? promptVersion?.contextToEvaluate ?? workflow?.contextToEvaluate;
+				
+				// Build the simulation closure
+				const outputFunctionToExecute = simulationYieldsOutputFunctionClosure<T>(
+					testRun.id,
+					workspaceId,
+					config.simulationConfig,
+					outputFunction,
+					APITestRunService,
+					entityType,
+					promptVersionId,
+					workflowIdForSim,
+					row.id,
+					input,
+					scenario,
+					expectedSteps,
+					contextToEvaluateForSimulation,
+					timeoutInMinutes,
+					logger,
+				);
+
+				// Execute the simulation
+				const output = await runOutputFunction(outputFunctionToExecute, row.data);
+
+				if (output.retrievedContextToEvaluate) {
+					if (contextToEvaluateForSimulation) {
+						logger.info(
+							`Detected retrieved context returned from output function for row ${
+								index + 1
+							} that had contextToEvaluate set from the dataset.\nOverriding the contextToEvaluate from dataset with the retrieved context`,
+						);
+					}
+					contextToEvaluateForSimulation = output.retrievedContextToEvaluate;
+				}
+
+				// 3. run evaluations
+				let localEvaluationResults: LocalEvaluationResult[] | undefined = undefined;
+				const localEvaluators = evaluators.filter((e) => typeof e !== "string" && "evaluationFunction" in e) as (
+					| LocalEvaluatorType<T>
+					| CombinedLocalEvaluatorType<T, Record<string, PassFailCriteriaType>>
+				)[];
+
+				if (localEvaluators.length > 0) {
+					localEvaluationResults = await runLocalEvaluations(
+						localEvaluators,
+						row.data,
+						output as any,
+						contextToEvaluateForSimulation,
+					)
+				}
+
+				// 4. Build output for push
+				// Find all platform evaluators with variableMapping
+				const platformEvaluatorsWithMangler = evaluators.filter(
+					(e): e is PlatformEvaluator =>
+						typeof e !== "string" && !("evaluationFunction" in e) && "variableMapping" in e && typeof e.variableMapping === "object",
+				);
+
+				let evaluatorOutputOverrides: Record<string, Record<string, string | undefined>> | undefined;
+				evaluatorOutputOverrides = {};
+				for (const platformEval of platformEvaluatorsWithMangler) {
+					if (!platformEval.variableMapping) continue;
+					const mappingKeysList = Object.keys(platformEval.variableMapping);
+					if (mappingKeysList.length > 0) {
+						const evalConfig = platformEvaluatorsConfig.find((c) => c.name === platformEval.name);
+						if (!evalConfig) continue;
+
+						const mappingResult: Record<string, string | undefined> = {};
+						
+						// Resolve persona with priority: dataset column > simulation config
+						let datasetPersona: string | undefined;
+						for (const [key, value] of Object.entries(row.data)) {
+							if (key.toLowerCase() === "persona" && value != null) {
+								const personaStr = String(value).trim();
+								if (personaStr) {
+									datasetPersona = personaStr;
+									break;
+								}
+							}
+						}
+						
+						let simconfigPersona: string | undefined;
+						if (config.simulationConfig?.persona && !datasetPersona) {
+							if (typeof config.simulationConfig.persona === "string") {
+								simconfigPersona = config.simulationConfig.persona;
+							} else {
+								const val = row.data[config.simulationConfig.persona.payload];
+								simconfigPersona = val != null ? String(val).trim() || undefined : undefined;
+							}
+						}
+						
+						const persona = datasetPersona ?? simconfigPersona ?? "";
+
+						const runObj = {
+							input,
+							output: output.data,
+							retrieval: contextToEvaluateForSimulation,
+							toolCalls: [],
+							scenario,
+							persona,
+							messages: output.messages,
+							...output,
+						};
+
+						for (const key of mappingKeysList) {
+							const mappingFn = platformEval.variableMapping[key];
+							if (!mappingFn) continue;
+							try {
+								const version = workflow
+									? {
+											id: workflow.id,
+											type: "workflow" as const,
+										}
+									: promptVersion
+										? {
+												id: promptVersion.id,
+												type: "prompt" as const,
+											}
+										: undefined;
+
+								mappingResult[key] = mappingFn(runObj, row.data, version);
+							} catch (e) {
+								logger.error(`Error in variable mapping for key "${key}": ${e instanceof Error ? e.message : String(e)}`);
+							}
+						}
+						evaluatorOutputOverrides[evalConfig.id] = mappingResult;
+					}
+				}
+
+				// Simulation: cost/usage in simulationMeta, no runConfig
+				try {
+					await APITestRunService.pushTestRunEntry({
+						testRun: { ...testRun, datasetId, datasetEntryId: row.id },
+						entry: {
+							input,
+							output: output.data,
+							meta: {
+								sdkVariables:
+									evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
+										? Object.entries(evaluatorOutputOverrides).reduce(
+												(acc, [id, val]) => {
+													acc[id] = {
+														type: VariableType.JSON,
+														payload: JSON.stringify(val),
+													};
+													return acc;
+												},
+												{} as Record<string, Variable>,
+											)
+										: undefined,
+							},
+							expectedOutput,
+							contextToEvaluate: contextToEvaluateForSimulation,
+							scenario,
+							expectedSteps,
+							dataEntry: row.data,
+							localEvaluationResults: localEvaluationResults
+							? localEvaluationResults.map((result) => ({
+								...result,
+								id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
+							}))
+							: undefined,
+							simulationMeta: output.simulationMeta,
+						},
+						localSimulation: true,
+					});
+				} catch (pushError) {
+					const testRunEntryId = output?.simulationMeta?.testRunEntryId;
+					if (testRunEntryId) {
+						try {
+							await APITestRunService.updateSimulationStatus(testRunEntryId, "FAILED");
+						} catch (cleanupError) {
+							const msg = `Failed to mark simulation as failed after push error (testRunEntryId: ${testRunEntryId}): ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`;
+							"error" in logger && typeof logger.error === "function" ? logger.error(msg) : logger.info(msg);
+						}
+					}
+					throw pushError;
+				}
+
+				// 5. log the test run entry with local evaluation results
+				logger.processed(`Ran test run entry ${index + 1}`, {
+					datasetEntry: row.data as Data<T>,
+					output,
+					evaluationResults: localEvaluationResults,
+				});
+
+				return;
+			} // Make sure if its local workflow or remote workflow
+			else if (outputFunction || evaluators.filter((e) => typeof e !== "string").length > 0) {
 				let outputFunctionToExecute: (data: Data<T>) => YieldedOutput | Promise<YieldedOutput>;
 				if (outputFunction) {
 					outputFunctionToExecute = outputFunction;
-				} else {
+				}
+				else {
 					// Check if we need to use simulation endpoints (simulationConfig + local evaluators)
 					const hasLocalEvaluators =
 						evaluators.filter((e) => typeof e !== "string" && "evaluationFunction" in e).length > 0;
@@ -321,25 +527,44 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 					const mappingKeysList = Object.keys(platformEval.variableMapping);
 					if (mappingKeysList.length > 0) {
 						const evalConfig = platformEvaluatorsConfig.find((c) => c.name === platformEval.name);
-						if (!evalConfig) continue;
+					if (!evalConfig) continue;
 
-						const mappingResult: Record<string, string | undefined> = {};
-						const persona = config.simulationConfig?.persona
-							? typeof config.simulationConfig.persona === "string"
-								? config.simulationConfig.persona
-								: (row.data[config.simulationConfig.persona.payload] ?? "")
-							: "";
+					const mappingResult: Record<string, string | undefined> = {};
+					
+					// Resolve persona with priority: dataset column > simulation config
+					let datasetPersona: string | undefined;
+					for (const [key, value] of Object.entries(row.data)) {
+						if (key.toLowerCase() === "persona" && value != null) {
+							const personaStr = String(value).trim();
+							if (personaStr) {
+								datasetPersona = personaStr;
+								break;
+							}
+						}
+					}
+					
+					let simconfigPersona: string | undefined;
+					if (config.simulationConfig?.persona) {
+						if (typeof config.simulationConfig.persona === "string") {
+							simconfigPersona = config.simulationConfig.persona;
+						} else {
+							const val = row.data[config.simulationConfig.persona.payload];
+							simconfigPersona = val != null ? String(val).trim() || undefined : undefined;
+						}
+					}
+					
+					const persona = datasetPersona ?? simconfigPersona ?? "";
 
-						const runObj = {
-							input,
-							output: output.data,
-							retrieval: contextToEvaluate,
-							toolCalls: [],
-							scenario,
-							persona,
-							messages: output.messages,
-							...output,
-						};
+					const runObj = {
+						input,
+						output: output.data,
+						retrieval: contextToEvaluate,
+						toolCalls: [],
+						scenario,
+						persona,
+						messages: output.messages,
+						...output,
+					};
 
 						for (const key of mappingKeysList) {
 							const mappingFn = platformEval.variableMapping[key];
@@ -371,57 +596,70 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 					}
 				}
 
-				await APITestRunService.pushTestRunEntry({
-					testRun: { ...testRun, datasetId, datasetEntryId: row.id },
-					runConfig: output.meta
-						? {
-								cost: output.meta.cost,
-								usage: output.meta.usage
-									? "completionTokens" in output.meta.usage
-										? {
-												completion_tokens: output.meta.usage.completionTokens,
-												prompt_tokens: output.meta.usage.promptTokens,
-												total_tokens: output.meta.usage.totalTokens,
-												latency: output.meta.usage.latency,
-											}
-										: {
-												latency: output.meta.usage.latency,
-											}
-									: undefined,
-							}
-						: undefined,
-					entry: {
-						input,
-						output: output.data,
-						meta: {
-							sdkVariables:
-								evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
-									? Object.entries(evaluatorOutputOverrides).reduce(
-											(acc, [id, val]) => {
-												acc[id] = {
-													type: VariableType.JSON,
-													payload: JSON.stringify(val),
-												};
-												return acc;
-											},
-											{} as Record<string, Variable>,
-										)
-									: undefined,
-						},
-						expectedOutput,
-						contextToEvaluate,
-						scenario,
-						expectedSteps,
-						dataEntry: row.data,
-						localEvaluationResults: localEvaluationResults
-							? localEvaluationResults.map((result) => ({
-									...result,
-									id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
-								}))
+				try {
+					await APITestRunService.pushTestRunEntry({
+						testRun: { ...testRun, datasetId, datasetEntryId: row.id },
+						runConfig: output.meta
+							? {
+									cost: output.meta.cost,
+									usage: output.meta.usage
+										? "completionTokens" in output.meta.usage
+											? {
+													completion_tokens: output.meta.usage.completionTokens,
+													prompt_tokens: output.meta.usage.promptTokens,
+													total_tokens: output.meta.usage.totalTokens,
+													latency: output.meta.usage.latency,
+												}
+											: {
+													latency: output.meta.usage.latency,
+												}
+										: undefined,
+								}
 							: undefined,
-						simulationMeta: output.simulationMeta,
-					},
-				});
+						entry: {
+							input,
+							output: output.data,
+							meta: {
+								sdkVariables:
+									evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
+										? Object.entries(evaluatorOutputOverrides).reduce(
+												(acc, [id, val]) => {
+													acc[id] = {
+														type: VariableType.JSON,
+														payload: JSON.stringify(val),
+													};
+													return acc;
+												},
+												{} as Record<string, Variable>,
+											)
+										: undefined,
+							},
+							expectedOutput,
+							contextToEvaluate,
+							scenario,
+							expectedSteps,
+							dataEntry: row.data,
+							localEvaluationResults: localEvaluationResults
+								? localEvaluationResults.map((result) => ({
+										...result,
+										id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
+									}))
+								: undefined,
+							simulationMeta: output.simulationMeta,
+						},
+					});
+				} catch (pushError) {
+					const testRunEntryId = output?.simulationMeta?.testRunEntryId;
+					if (testRunEntryId) {
+						try {
+							await APITestRunService.updateSimulationStatus(testRunEntryId, "FAILED");
+						} catch (cleanupError) {
+							const msg = `Failed to mark simulation as failed after push error (testRunEntryId: ${testRunEntryId}): ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`;
+							"error" in logger && typeof logger.error === "function" ? logger.error(msg) : logger.info(msg);
+						}
+					}
+					throw pushError;
+				}
 
 				// 5. log the test run entry with local evaluation results
 				logger.processed(`Ran test run entry ${index + 1}`, {

--- a/src/lib/testRun/testRun.ts
+++ b/src/lib/testRun/testRun.ts
@@ -11,7 +11,7 @@ import type {
 	PassFailCriteriaType,
 	PlatformEvaluator,
 } from "../models/evaluator";
-import type { TestRunBuilder, TestRunConfig, YieldedOutput } from "../models/testRun";
+import type { TestRunBuilder, TestRunConfig } from "../models/testRun";
 
 import { CSVFile } from "../utils/csvParser";
 import { Semaphore } from "../utils/semaphore";
@@ -27,10 +27,13 @@ import {
 	simulationPromptVersionIdOutputFunctionClosure,
 	simulationWorkflowIdOutputFunctionClosure,
 	simulationYieldsOutputFunctionClosure,
+	runOutputFunctionWithTracing,
 	workflowIdOutputFunctionClosure,
 } from "./runUtils";
 import { sanitizeData, sanitizeEvaluators } from "./sanitizationUtils";
 import { buildErrorMessage, calculatePollingInterval, createStatusTable, getLocalEvaluatorNameToIdAndPassFailCriteriaMap } from "./utils";
+import { MaximLogger } from "../logger/logger";
+import { v4 as uuidv4 } from "uuid";
 
 /**
  * Creates a new TestRunBuilder with the given configuration.
@@ -64,6 +67,8 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 	withWorkflowId: (id, contextToEvaluate) => createTestRunBuilder({ ...config, workflow: { id, contextToEvaluate } }),
 	withSimulationConfig: (simulationConfig) => createTestRunBuilder({ ...config, simulationConfig }),
 	yieldsOutput: (outputFunction) => createTestRunBuilder({ ...config, outputFunction }),
+	yieldsOutputWithTracing: (outputFunctionWithTracing, maximLogger, disableDefaultTraceCreation) =>
+		createTestRunBuilder({ ...config, outputFunctionWithTracing, maximLogger, disableDefaultTraceCreation: disableDefaultTraceCreation ?? false }),
 	withLogger: (logger) => createTestRunBuilder({ ...config, logger }),
 	getConfig: () => config,
 	withConcurrency: (concurrency) => createTestRunBuilder({ ...config, concurrency }),
@@ -80,16 +85,23 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 		if (!config.workspaceId) {
 			errors.push("Workspace Id is required to run a test.");
 		}
-		if (!config.outputFunction && !config.promptVersion && !config.promptChainVersion && !config.workflow) {
+		if (
+			!config.outputFunction &&
+			!config.outputFunctionWithTracing &&
+			!config.promptVersion &&
+			!config.promptChainVersion &&
+			!config.workflow
+		) {
 			errors.push(
-				"Output function or prompt version id, prompt chain version id, or workflow id is required to run a test. You can use either yieldsOutput, withPromptVersionId, withPromptChainVersionId or withWorkflowId to set them respectively.",
+				"Output function or prompt version id, prompt chain version id, or workflow id is required to run a test. You can use either yieldsOutput, yieldsOutputWithTracing, withPromptVersionId, withPromptChainVersionId or withWorkflowId to set them respectively.",
 			);
 		}
 		const hasOutputFunction = !!config.outputFunction;
 		const hasPromptVersion = !!config.promptVersion;
 		const hasPromptChainVersion = !!config.promptChainVersion;
 		const hasWorkflow = !!config.workflow;
-		const outputSourceCount = (hasOutputFunction ? 1 : 0) + (hasPromptVersion ? 1 : 0) + (hasPromptChainVersion ? 1 : 0) + (hasWorkflow ? 1 : 0);
+		const hasOutputFunctionWithTracing = !!config.outputFunctionWithTracing;
+		const outputSourceCount = (hasOutputFunction ? 1 : 0) + (hasOutputFunctionWithTracing ? 1 : 0) + (hasPromptVersion ? 1 : 0) + (hasPromptChainVersion ? 1 : 0) + (hasWorkflow ? 1 : 0);
 
 		// Simulation + yieldsOutput: requires outputFunction + (promptVersion OR workflow)
 		if (config.simulationConfig && hasOutputFunction) {
@@ -109,14 +121,17 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 			errors.push("Data or dataset id is required to run a test.");
 		}
 		if (config.simulationConfig) {
+			if (config.outputFunctionWithTracing) {
+				errors.push("Simulation config cannot be used with yieldsOutputWithTracing. Use yieldsOutput instead.");
+			}
 			if (config.promptChainVersion) {
 				errors.push("Simulation config cannot be used with withPromptChainVersionId. Use withWorkflowId, withPromptVersionId, or yieldsOutput instead.");
 			}
 			if (!config.workflow && !config.promptVersion && !config.outputFunction) {
-				errors.push("Simulation config requires either withWorkflowId, withPromptVersionId, or yieldsOutput to be set.");
+				errors.push("Simulation config requires either withWorkflowId, withPromptVersionId, yieldsOutput to be set.");
 			}
 			if (config.simulationConfig.responseFields && config.simulationConfig.responseFields.length > 0 && !config.workflow) {
-				errors.push("responseFields in simulationConfig can only be used with withWorkflowId, not with withPromptVersionId or yieldsOutput.");
+				errors.push("responseFields in simulationConfig can only be used with withWorkflowId, not with withPromptVersionId, yieldsOutput or yieldsOutputWithTracing.");
 			}
 		}
 
@@ -159,11 +174,13 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 		const evaluators = config.evaluators;
 		const humanEvaluationConfig = config.humanEvaluationConfig;
 		const outputFunction = config.outputFunction;
+		const outputFunctionWithTracing = config.outputFunctionWithTracing;
 		const promptVersion = config.promptVersion;
 		const promptChainVersion = config.promptChainVersion;
 		const workflow = config.workflow;
 		const tags = config.tags;
 		const failedEntryIndices: number[] = [];
+		let internalMaximLogger: MaximLogger | undefined = undefined;
 		const localEvaluatorNameToIdAndPassFailCriteriaMap = getLocalEvaluatorNameToIdAndPassFailCriteriaMap(
 			evaluators.filter(
 				(e): e is LocalEvaluatorType<T> | CombinedLocalEvaluatorType<T, Record<string, PassFailCriteriaType>> =>
@@ -409,12 +426,16 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 
 				return;
 			} // Make sure if its local workflow or remote workflow
-			else if (outputFunction || evaluators.filter((e) => typeof e !== "string").length > 0) {
-				let outputFunctionToExecute: (data: Data<T>) => YieldedOutput | Promise<YieldedOutput>;
+			else if (outputFunction || outputFunctionWithTracing || evaluators.filter((e) => typeof e !== "string").length > 0) {
+			// Make sure if its local workflow or remote workflow
+				let outputFunctionToExecute: NonNullable<TestRunConfig<T>["outputFunction"]> | undefined;
+				let outputFunctionWithTracingToExecute: NonNullable<TestRunConfig<T>["outputFunctionWithTracing"]> | undefined;
+
 				if (outputFunction) {
 					outputFunctionToExecute = outputFunction;
-				}
-				else {
+				} else if (outputFunctionWithTracing) {
+					outputFunctionWithTracingToExecute = outputFunctionWithTracing;
+				} else {
 					// Check if we need to use simulation endpoints (simulationConfig + local evaluators)
 					const hasLocalEvaluators =
 						evaluators.filter((e) => typeof e !== "string" && "evaluationFunction" in e).length > 0;
@@ -477,18 +498,38 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 						);
 					} else {
 						throw new Error(
-							"Found no output function to execute, please make sure you have either `yieldsOutput`, `withPromptVersionId`, `withPromptChainVersionId` or `withWorkflowId` set.",
+							"Found no output function to execute, please make sure you have either `yieldsOutput`, `yieldsOutputWithTracing`, `withPromptVersionId`, `withPromptChainVersionId` or `withWorkflowId` set.",
 						);
 					}
 				}
 
-				const output = await runOutputFunction(outputFunctionToExecute, row.data);
+				const testRunEntry = await APITestRunService.createTestRunEntry({
+					testRun: { ...testRun, datasetId, datasetEntryId: row.id },
+				});
+
+				const traceId = uuidv4();
+				if (!config.disableDefaultTraceCreation && internalMaximLogger) {
+					try {
+						const testRunEntryTrace = internalMaximLogger.trace({
+							id: traceId,
+							name: `Test Run Entry ${index + 1}`,
+						})
+						testRunEntryTrace.addTag("testRunEntryId", testRunEntry.id);
+						testRunEntryTrace.addTag("testRunId", testRun.id);
+					} catch (e) {
+						logger.error(`Error creating trace for test run entry ${index + 1}: ${e instanceof Error ? e.message : String(e)}`);
+					}
+				}
+
+				const output =
+					outputFunctionWithTracingToExecute !== undefined
+						? await runOutputFunctionWithTracing(outputFunctionWithTracingToExecute, row.data, traceId)
+						: await runOutputFunction(outputFunctionToExecute!, row.data);
 
 				if (output.retrievedContextToEvaluate) {
 					if (contextToEvaluate) {
 						logger.info(
-							`Detected retrieved context returned from output function for row ${
-								index + 1
+							`Detected retrieved context returned from output function for row ${index + 1
 							} that had contextToEvaluate set from the dataset.\nOverriding the contextToEvaluate from dataset with the retrieved context`,
 						);
 					}
@@ -572,19 +613,19 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 							try {
 								const version = workflow
 									? {
-											id: workflow.id,
-											type: "workflow" as const,
-										}
+										id: workflow.id,
+										type: "workflow" as const,
+									}
 									: promptVersion
 										? {
-												id: promptVersion.id,
-												type: "prompt" as const,
-											}
+											id: promptVersion.id,
+											type: "prompt" as const,
+										}
 										: promptChainVersion
 											? {
-													id: promptChainVersion.id,
-													type: "promptChain" as const,
-												}
+												id: promptChainVersion.id,
+												type: "promptChain" as const,
+											}
 											: undefined;
 
 								mappingResult[key] = mappingFn(runObj, row.data, version);
@@ -597,57 +638,60 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				}
 
 				try {
-					await APITestRunService.pushTestRunEntry({
-						testRun: { ...testRun, datasetId, datasetEntryId: row.id },
-						runConfig: output.meta
-							? {
-									cost: output.meta.cost,
-									usage: output.meta.usage
-										? "completionTokens" in output.meta.usage
-											? {
-													completion_tokens: output.meta.usage.completionTokens,
-													prompt_tokens: output.meta.usage.promptTokens,
-													total_tokens: output.meta.usage.totalTokens,
-													latency: output.meta.usage.latency,
-												}
-											: {
-													latency: output.meta.usage.latency,
-												}
-										: undefined,
-								}
-							: undefined,
-						entry: {
-							input,
-							output: output.data,
-							meta: {
-								sdkVariables:
-									evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
-										? Object.entries(evaluatorOutputOverrides).reduce(
-												(acc, [id, val]) => {
-													acc[id] = {
-														type: VariableType.JSON,
-														payload: JSON.stringify(val),
-													};
-													return acc;
-												},
-												{} as Record<string, Variable>,
-											)
-										: undefined,
-							},
-							expectedOutput,
-							contextToEvaluate,
-							scenario,
-							expectedSteps,
-							dataEntry: row.data,
-							localEvaluationResults: localEvaluationResults
-								? localEvaluationResults.map((result) => ({
-										...result,
-										id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
-									}))
+				await APITestRunService.pushTestRunEntry({
+					testRun: { ...testRun, datasetId, datasetEntryId: row.id },
+					runConfig: output.meta
+						? {
+							cost: output.meta.cost,
+							usage: output.meta.usage
+								? "completionTokens" in output.meta.usage
+									? {
+										completion_tokens: output.meta.usage.completionTokens,
+										prompt_tokens: output.meta.usage.promptTokens,
+										total_tokens: output.meta.usage.totalTokens,
+										latency: output.meta.usage.latency,
+									}
+									: {
+										latency: output.meta.usage.latency,
+									}
 								: undefined,
-							simulationMeta: output.simulationMeta,
+						}
+						: undefined,
+					entry: {
+						id: testRunEntry.id,
+						input,
+						output: output.data,
+						meta: {
+							sdkVariables:
+								evaluatorOutputOverrides && Object.keys(evaluatorOutputOverrides).length > 0
+									? Object.entries(evaluatorOutputOverrides).reduce(
+										(acc, [id, val]) => {
+											acc[id] = {
+												type: VariableType.JSON,
+												payload: JSON.stringify(val),
+											};
+											return acc;
+										},
+										{} as Record<string, Variable>,
+									)
+									: undefined,
+							connectedTraceId: internalMaximLogger ? traceId : undefined,
 						},
-					});
+						expectedOutput,
+						contextToEvaluate,
+						scenario,
+						expectedSteps,
+						dataEntry: row.data,
+						localEvaluationResults: localEvaluationResults
+							? localEvaluationResults.map((result) => ({
+								...result,
+								id: localEvaluatorNameToIdAndPassFailCriteriaMap.get(result.name)!.id,
+							}))
+							: undefined,
+						simulationMeta: output.simulationMeta,
+					},
+				});
+					
 				} catch (pushError) {
 					const testRunEntryId = output?.simulationMeta?.testRunEntryId;
 					if (testRunEntryId) {
@@ -739,6 +783,12 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				),
 			];
 
+			if (config.maximLogger) {
+				internalMaximLogger = config.maximLogger;
+			}
+
+			const tagsEnrichedWithRepoId = config.maximLogger ? [...(tags ?? []), `repoId:${config.maximLogger.id}`] : tags;
+
 			const testRun = await APITestRunService.createTestRun(
 				name,
 				workspaceId,
@@ -749,8 +799,9 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 				promptVersion?.id,
 				promptChainVersion?.id,
 				humanEvaluationConfig,
-				tags,
+				tagsEnrichedWithRepoId,
 				config.simulationConfig,
+				internalMaximLogger?.id,
 			);
 
 			try {
@@ -974,8 +1025,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 										logger.error(
 											buildErrorMessage(
 												new Error(
-													`=> Skipping page ${page - 1}\nError while sanitizing reponse as per data structure: ${
-														err.message
+													`=> Skipping page ${page - 1}\nError while sanitizing reponse as per data structure: ${err.message
 													}\n\tGot response: ${JSON.stringify(fetchedData)}`,
 													{
 														cause: err,
@@ -987,8 +1037,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 										logger.error(
 											buildErrorMessage(
 												new Error(
-													`=> Skipping page ${
-														page - 1
+													`=> Skipping page ${page - 1
 													}\nError while sanitizing reponse as per data structure\n\tGot response: ${JSON.stringify(fetchedData)}`,
 													{
 														cause: err,
@@ -1107,8 +1156,7 @@ export const createTestRunBuilder = <T extends DataStructure | undefined = undef
 					throw new Error(
 						`Test run is taking over timeout period (${Math.round(
 							timeoutInMinutes,
-						)} minutes) to complete, please check the report on our web portal directly: ${config.baseUrl}/workspace/${
-							config.workspaceId
+						)} minutes) to complete, please check the report on our web portal directly: ${config.baseUrl}/workspace/${config.workspaceId
 						}/testrun/${testRun.id}`,
 					);
 				}

--- a/src/lib/testRunWithSimulation.test.ts
+++ b/src/lib/testRunWithSimulation.test.ts
@@ -1,19 +1,22 @@
 import "dotenv/config";
 import fs from "node:fs";
+import OpenAI from "openai";
 import {
 	createCustomCombinedEvaluatorsFor,
 	createCustomEvaluator,
 	createDataStructure,
 	Data,
+	DataStructure,
 	LocalEvaluationResult,
 	Maxim,
 	TestRunLogger,
 	TestRunConfig,
 	YieldedOutput,
 } from "../../index";
+import type { SimulationConversationTurn, SimulationContext, CustomSimulatorConfig } from "../../index";
 
 const config = JSON.parse(fs.readFileSync(`${process.cwd()}/testSimulationTestConfig.json`, "utf-8"));
-const env = "beta";
+const env = "prod";
 
 if (!config[env].apiKey) throw new Error("Missing API_KEY environment variable");
 if (!config[env].workspaceId) throw new Error("Missing WORKSPACE_ID environment variable");
@@ -30,26 +33,81 @@ const workflowId: string = config[env].workflowId;
 
 // ===== Data Structure =====
 const dataStructure = createDataStructure({
+	"Expected Steps": "EXPECTED_STEPS",
+	Scenario: "SCENARIO",
+	Persona: "VARIABLE"
+});
+
+// Data structure with Input (required for local-execution simulation)
+const dataStructureWithInput = createDataStructure({
+	Input: "INPUT",
+	Scenario: "SCENARIO",
+	"Expected Steps": "EXPECTED_STEPS",
+	Context: "CONTEXT_TO_EVALUATE",
+});
+
+// Data structure with Persona for persona-from-dataset tests
+const dataStructureWithoutPersona = createDataStructure({
 	Input: "INPUT",
 	"Expected Steps": "EXPECTED_STEPS",
 	Scenario: "SCENARIO",
 });
 
+// Data structure with variables for custom simulator template tests
+const dataStructureWithVariables = createDataStructure({
+	Input: "INPUT",
+	Scenario: "SCENARIO",
+	Topic: "VARIABLE",
+	"Expected Steps": "EXPECTED_STEPS",
+});
+
 // ===== Manual Test Data =====
 const manualData: Data<typeof dataStructure>[] = [
 	{
-		Input: "What is the significance of the 'Pale Blue Dot' in 'Cosmos'?",
 		"Expected Steps": `1.The "Pale Blue Dot" refers to an image of Earth taken by the Voyager 1 spacecraft from a distance of about 3.7 billion miles. In "Cosmos," Carl Sagan reflects on the image to illustrate the fragility and insignificance of Earth in the vastness of the universe, emphasizing the need for humility and unity among humanity.
 		\n2. Yes. Sagan connects the "Pale Blue Dot" idea to humanity's tendency to think of itself as central or unique. By showing how tiny Earth is, he challenges that view and instead presents humans as part of a much larger cosmic story, made from the same matter as stars and governed by the same natural laws.`,
 		Scenario: "Question about Pale Blue Dot",
+		Persona: "You are an enthusiastic science student, you ask alot of questions and in the end of all of your questions u say H20. ",
 	},
 	{
-		Input: "Explain quantum entanglement in simple terms.",
 		"Expected Steps": `1. Quantum entanglement is a phenomenon where two or more particles become connected in such a way that the state of one particle instantly affects the state of another, regardless of the distance between them.
 		\n2. This connection happens instantaneously, faster than light, which challenges our classical understanding of physics.`,
 		Scenario: "Science explanation request",
+		Persona: "You are an enthusiastic science student, you ask alot of questions and in the end of all of your questions u say H20. "
 	},
 ];
+
+// Manual data with Input (for local-execution simulation tests)
+const manualDataWithInput: Data<typeof dataStructureWithInput>[] = [
+	{
+		Input: "What is the Pale Blue Dot?",
+		Scenario: "Question about Pale Blue Dot",
+		"Expected Steps": "1. Answer the question.\n2. Provide context.",
+		Context: "Context 1",
+	},
+];
+
+// Manual data with variables for custom simulator template tests
+const manualDataWithVariables: Data<typeof dataStructureWithVariables>[] = [
+	{
+		Input: "What is the Pale Blue Dot?",
+		Scenario: "Question about the Pale Blue Dot photograph",
+		Topic: "astronomy and space exploration",
+		"Expected Steps": "1. Answer the question.\n2. Provide context.",
+	},
+];
+
+// Custom simulator prompts
+const CUSTOM_SIMULATOR_PROMPT_BASIC =
+	"You are a curious user interested in science. " +
+	"Ask one short follow-up question about the agent's last response. " +
+	"Keep questions concise and relevant.";
+
+const CUSTOM_SIMULATOR_PROMPT_WITH_VARS =
+	"You are a curious user interested in {{ Topic }}. " +
+	"The scenario is: {{ Scenario }}. " +
+	"Ask one short follow-up question about the agent's last response, " +
+	"staying on topic.";
 
 // ===== Local Evaluators =====
 
@@ -115,7 +173,9 @@ const simulationOutputsEvaluator = createCustomEvaluator<typeof dataStructure>(
 const localCombinedEvaluator = createCustomCombinedEvaluatorsFor("length-check", "contains-input").build<typeof dataStructure>(
 	async (result, data) => {
 		const lengthScore = result.output.length >= data["Expected Steps"].length ? 1 : 0;
-		const containsScore = result.output.includes(data.Input) ? 1 : 0;
+		const containsScore = result.output.includes(result.simulationOutputs?.join("\n") ?? "") ? 1 : 0;
+		console.log("result.simulationOutputs", result.simulationOutputs);
+		console.log("result.simulationOutputs.join(\n)", result.simulationOutputs?.join("\n"));
 		return {
 			"length-check": {
 				score: lengthScore,
@@ -153,6 +213,57 @@ const localCombinedEvaluator = createCustomCombinedEvaluatorsFor("length-check",
 	},
 );
 
+// Combined local evaluator for dataset-compatible data structure
+const localCombinedEvaluatorForDataset = createCustomCombinedEvaluatorsFor("length-check", "contains-input").build<typeof dataStructureWithoutPersona>(
+	async (result, data) => {
+		const lengthScore = result.output && data["Expected Steps"] && result.output.length >= data["Expected Steps"].length ? 1 : 0;
+		const containsScore = result.output.includes(result.simulationOutputs?.join("\n") ?? "") ? 1 : 0;
+		return {
+			"length-check": {
+				score: lengthScore,
+				reasoning: "Output length is sufficient",
+			},
+			"contains-input": {
+				score: containsScore,
+				reasoning: "Output contains input",
+			},
+		};
+	},
+	{
+		"length-check": {
+			onEachEntry: { scoreShouldBe: ">=", value: 1 },
+			forTestrunOverall: { overallShouldBe: ">=", value: 100, for: "percentageOfPassedResults" },
+		},
+		"contains-input": {
+			onEachEntry: { scoreShouldBe: ">=", value: 1 },
+			forTestrunOverall: { overallShouldBe: ">=", value: 100, for: "percentageOfPassedResults" },
+		},
+	},
+);
+
+// Local evaluator for data structure with Persona (same logic, different type)
+const localSingleEvaluatorWithPersona = createCustomEvaluator<typeof dataStructureWithoutPersona>(
+	"output-length-validator",
+	async (result, data) => {
+		const lengthScore = result.output && data["Expected Steps"] && result.output.length >= data["Expected Steps"].length ? 1 : 0;
+		return {
+			score: lengthScore,
+			reasoning: lengthScore === 1 ? "Output length is sufficient" : "Output length is insufficient",
+		};
+	},
+	{
+		onEachEntry: {
+			scoreShouldBe: ">=",
+			value: 1,
+		},
+		forTestrunOverall: {
+			overallShouldBe: ">=",
+			value: 100,
+			for: "percentageOfPassedResults",
+		},
+	},
+);
+
 // Boolean evaluator
 const localBooleanEvaluator = createCustomEvaluator<typeof dataStructure>(
 	"has-question-mark",
@@ -175,8 +286,268 @@ const localBooleanEvaluator = createCustomEvaluator<typeof dataStructure>(
 	},
 );
 
+// Local evaluator for dataStructureWithInput
+const localEvalWithInput = createCustomEvaluator<typeof dataStructureWithInput>(
+	"output-length-validator",
+	async (result, data) => {
+		const lengthScore = result.output.length >= (data["Expected Steps"]?.length ?? 0) ? 1 : 0;
+		return {
+			score: lengthScore,
+			reasoning: lengthScore === 1 ? "Output length is sufficient" : "Output length is insufficient",
+		};
+	},
+	{
+		onEachEntry: {
+			scoreShouldBe: ">=",
+			value: 1,
+		},
+		forTestrunOverall: {
+			overallShouldBe: ">=",
+			value: 100,
+			for: "percentageOfPassedResults",
+		},
+	},
+);
+
+// ===== yieldsOutput functions for local-execution simulation tests =====
+
+/**
+ * Basic yieldsOutput - input/output only (matches Python's yields_fn).
+ */
+const yieldsOutputBasic = async (
+	_data: Data<typeof dataStructureWithInput>,
+	simCtx?: SimulationContext,
+): Promise<YieldedOutput> => {
+	if (!simCtx) return { data: "Initial response" };
+	const inputText = (simCtx.currentUserInput?.["input"] as string) ?? "";
+	return { data: `Responding to: ${inputText}` };
+};
+
+/**
+ * yieldsOutput with conversation history (matches Python's yields_fn_with_context).
+ */
+const yieldsOutputWithContext = async (
+	_data: Data<typeof dataStructureWithInput>,
+	simCtx?: SimulationContext,
+): Promise<YieldedOutput> => {
+	if (!simCtx) return { data: "Initial response" };
+
+	const userInput = (simCtx.currentUserInput?.["input"] as string) ?? "";
+
+	// Build conversation history for your LLM call
+	const messages: { role: string; content: string }[] = [];
+	for (const turn of simCtx.conversationHistory) {
+		const userMsg = (turn.request?.["input"] as string) ?? "";
+		const assistantMsg = (turn.response?.["output"] as string) ?? (turn.response?.["data"] as string) ?? "";
+		if (userMsg) messages.push({ role: "user", content: userMsg });
+		if (assistantMsg) messages.push({ role: "assistant", content: assistantMsg });
+	}
+	messages.push({ role: "user", content: userInput });
+
+	return { data: `Turn ${simCtx.turnNumber}: Responding to '${userInput}'` };
+};
+
+/**
+ * yieldsOutput that returns STOP on turn 2 for stopTrigger tests (matches Python's yields_fn_stop).
+ */
+const yieldsOutputForStop = async (
+	_data: Data<typeof dataStructureWithInput>,
+	simCtx?: SimulationContext,
+): Promise<YieldedOutput> => {
+	if (!simCtx) return { data: "Initial" };
+	if (simCtx.turnNumber >= 2) return { data: "STOP" };
+	return { data: `Turn ${simCtx.turnNumber} response` };
+};
+
+/**
+ * yieldsOutput with LLM call for local-execution tests (matches Python's yields_fn_with_llm).
+ */
+const yieldsOutputWithLlm = async (
+	_data: Data<typeof dataStructureWithInput>,
+	simCtx?: SimulationContext,
+): Promise<YieldedOutput> => {
+	if (!simCtx) return { data: "Initial response" };
+
+	const userInput = (simCtx.currentUserInput?.["input"] as string) ?? "";
+
+	const messages: { role: "system" | "user" | "assistant"; content: string }[] = [];
+	for (const turn of simCtx.conversationHistory) {
+		const userMsg = (turn.request?.["input"] as string) ?? "";
+		const assistantMsg = (turn.response?.["output"] as string) ?? (turn.response?.["data"] as string) ?? "";
+		if (userMsg) messages.push({ role: "user", content: userMsg });
+		if (assistantMsg) messages.push({ role: "assistant", content: assistantMsg });
+	}
+	messages.push({ role: "user", content: userInput });
+
+	const openaiKey = process.env["OPENAI_API_KEY"];
+	if (openaiKey) {
+		try {
+			const openai = new OpenAI({ apiKey: openaiKey });
+			const resp = await openai.chat.completions.create({
+				model: "gpt-4o-mini",
+				messages,
+				max_tokens: 150,
+			});
+			return { data: resp.choices[0]?.message?.content ?? "" };
+		} catch (e) {
+			return { data: `[LLM fallback] Turn ${simCtx.turnNumber}: '${userInput}' - error: ${e}` };
+		}
+	}
+
+	// Fallback when no LLM
+	return { data: `Turn ${simCtx.turnNumber}: Responding to '${userInput}' (mock LLM)` };
+};
+
+// ===== Shared yieldsOutput callback for simulation tests =====
+const defaultYieldsOutput = async (
+	_data: Data<typeof dataStructure>,
+	simulationContext?: SimulationContext,
+) => {
+	// Log message history for debugging - verify conversationHistory is passed to yieldsOutput
+	if (simulationContext) {
+		console.log(`[yieldsOutput] Turn ${simulationContext.turnNumber} - conversationHistory length: ${simulationContext.conversationHistory?.length ?? 0}`);
+		console.log(`[yieldsOutput] totalCost: ${simulationContext.totalCost}, totalTokens: ${simulationContext.totalTokens}`);
+		console.log(
+			`[yieldsOutput] conversationHistory:`,
+			JSON.stringify(
+				simulationContext.conversationHistory?.map((t) => ({
+					turn: t.turn,
+					request: t.request,
+					responseOutput: t.response?.["output"] ?? t.response,
+				})),
+				null,
+				2,
+			),
+		);
+		console.log(`[yieldsOutput] currentUserInput:`, JSON.stringify(simulationContext.currentUserInput, null, 2));
+	}
+
+	const userMsg = simulationContext
+		? (simulationContext.currentUserInput?.["input"] as string) ??
+			(simulationContext.currentUserInput?.["message"] as string) ??
+			JSON.stringify(simulationContext.currentUserInput)
+		: "";
+	const response = simulationContext
+		? `Turn ${simulationContext.turnNumber}: Responding to "${userMsg}"`
+		: "Initial response";
+	return { data: response };
+};
+
+/**
+ * YieldsOutput that makes an actual LLM call using OpenAI.
+ * Converts conversationHistory to chat messages and calls gpt-4o-mini.
+ * Requires OPENAI_API_KEY in environment.
+ */
+const llmYieldsOutput = async (
+	_data: Data<typeof dataStructure>,
+	simulationContext?: SimulationContext,
+) => {
+	const openaiKey = process.env["OPENAI_API_KEY"];
+	if (!openaiKey) {
+		throw new Error("OPENAI_API_KEY is required for llmYieldsOutput. Set it in your .env file.");
+	}
+
+	// Log message history (same as defaultYieldsOutput)
+	if (simulationContext) {
+		console.log(`[llmYieldsOutput] Turn ${simulationContext.turnNumber} - conversationHistory length: ${simulationContext.conversationHistory?.length ?? 0}`);
+		console.log(
+			`[llmYieldsOutput] conversationHistory:`,
+			JSON.stringify(
+				simulationContext.conversationHistory?.map((t) => ({
+					turn: t.turn,
+					request: t.request,
+					responseOutput: t.response?.["output"] ?? t.response,
+				})),
+				null,
+				2,
+			),
+		);
+		console.log(`[llmYieldsOutput] currentUserInput:`, JSON.stringify(simulationContext.currentUserInput, null, 2));
+	}
+
+	// Build messages from conversationHistory + currentUserInput
+	const messages: { role: "system" | "user" | "assistant"; content: string }[] = [
+		{
+			role: "system",
+			content:
+				"You are an enthusiastic science student. You ask a lot of questions and at the end of all your questions you say H20. Keep responses concise.",
+		},
+	];
+
+	// Add conversation history (user/assistant turns)
+	if (simulationContext?.conversationHistory?.length) {
+		for (const turn of simulationContext.conversationHistory) {
+			const userContent = (turn.request?.["input"] as string) ?? (turn.request?.["message"] as string) ?? JSON.stringify(turn.request);
+			if (userContent) {
+				messages.push({ role: "user", content: userContent });
+			}
+			const assistantContent = (turn.response?.["output"] as string) ?? (typeof turn.response === "string" ? turn.response : JSON.stringify(turn.response));
+			if (assistantContent) {
+				messages.push({ role: "assistant", content: assistantContent });
+			}
+		}
+	}
+
+	// Add current user input
+	const currentUserContent = simulationContext
+		? (simulationContext.currentUserInput?.["input"] as string) ??
+			(simulationContext.currentUserInput?.["message"] as string) ??
+			JSON.stringify(simulationContext.currentUserInput)
+		: "";
+	if (currentUserContent) {
+		messages.push({ role: "user", content: currentUserContent });
+	}
+
+	console.log(`[llmYieldsOutput] Sending ${messages.length} messages to LLM`);
+
+	const openai = new OpenAI({ apiKey: openaiKey });
+	const completion = await openai.chat.completions.create({
+		model: "gpt-4o-mini",
+		messages,
+		max_tokens: 256,
+		temperature: 0.7,
+	});
+
+	const responseText = completion.choices[0]?.message?.content ?? "";
+	console.log(`[llmYieldsOutput] LLM response (turn ${simulationContext?.turnNumber ?? 0}):`, responseText.slice(0, 100) + (responseText.length > 100 ? "..." : ""));
+
+	return {
+		data: responseText,
+		meta: completion.usage
+			? {
+					usage: {
+						promptTokens: completion.usage.prompt_tokens,
+						completionTokens: completion.usage.completion_tokens,
+						totalTokens: completion.usage.total_tokens ?? 0,
+					},
+				}
+			: undefined,
+	};
+};
+
+const defaultYieldsOutputWithPersona = async (
+	_data: Data<typeof dataStructureWithoutPersona>,
+	simulationContext?: SimulationContext,
+) => {
+	// Log message history for debugging
+	if (simulationContext) {
+		console.log(`[yieldsOutputWithPersona] Turn ${simulationContext.turnNumber} - conversationHistory length: ${simulationContext.conversationHistory?.length ?? 0}`);
+		console.log(`[yieldsOutputWithPersona] currentUserInput:`, JSON.stringify(simulationContext.currentUserInput, null, 2));
+	}
+
+	const userMsg = simulationContext
+		? (simulationContext.currentUserInput?.["input"] as string) ??
+			(simulationContext.currentUserInput?.["message"] as string) ??
+			JSON.stringify(simulationContext.currentUserInput)
+		: "";
+	const response = simulationContext
+		? `Turn ${simulationContext.turnNumber}: Responding to "${userMsg}"`
+		: "Initial response";
+	return { data: response };
+};
+
 // ===== Custom Logger =====
-class TestLogger implements TestRunLogger<typeof dataStructure> {
+class TestLogger<T extends DataStructure = typeof dataStructure> implements TestRunLogger<T> {
 	constructor(private testCase: string) {}
 
 	error(message: string) {
@@ -190,7 +561,7 @@ class TestLogger implements TestRunLogger<typeof dataStructure> {
 	processed(
 		message: string,
 		data: {
-			datasetEntry: Data<typeof dataStructure>;
+			datasetEntry: Data<T>;
 			output?: YieldedOutput;
 			evaluationResults?: LocalEvaluationResult[];
 		},
@@ -216,16 +587,16 @@ describe("Comprehensive Test Runs with Simulation", () => {
 	describe("Valid Combinations - Prompt Version", () => {
 		test("Prompt + Dataset + Local Single Evaluator", async () => {
 			const testCase = "prompt-dataset-local-single";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
-				.withEvaluators(localSingleEvaluator)
+				.withEvaluators(localSingleEvaluatorWithPersona)
 				.withLogger(logger)
 				.run(120);
 
@@ -237,16 +608,16 @@ describe("Comprehensive Test Runs with Simulation", () => {
 
 		test("Prompt + Dataset + Local Combined Evaluator", async () => {
 			const testCase = "prompt-dataset-local-combined";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
-				.withEvaluators(localCombinedEvaluator)
+				.withEvaluators(localCombinedEvaluatorForDataset)
 				.withLogger(logger)
 				.run(120);
 
@@ -258,16 +629,16 @@ describe("Comprehensive Test Runs with Simulation", () => {
 
 		test("Prompt + Dataset + Maxim Evaluator", async () => {
 			const testCase = "prompt-dataset-maxim-eval";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
-				.withEvaluators("Faithfulness")
+				.withEvaluators("Bias")
 				.withLogger(logger)
 				.run(120);
 
@@ -279,15 +650,15 @@ describe("Comprehensive Test Runs with Simulation", () => {
 
 		test("Prompt + Dataset + Local + Maxim Evaluators", async () => {
 			const testCase = "prompt-dataset-local-maxim";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
-				.withEvaluators(localSingleEvaluator, "Faithfulness")
+				.withEvaluators(localSingleEvaluatorWithPersona, "Bias")
 				.withLogger(logger)
 				.run(120);
 
@@ -305,7 +676,7 @@ describe("Comprehensive Test Runs with Simulation", () => {
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
 				.withDataStructure(dataStructure)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(manualData)
 				.withEvaluators(localSingleEvaluator)
 				.withLogger(logger)
@@ -325,7 +696,7 @@ describe("Comprehensive Test Runs with Simulation", () => {
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
 				.withDataStructure(dataStructure)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(manualData)
 				.withEvaluators(localCombinedEvaluator)
 				.withLogger(logger)
@@ -345,7 +716,7 @@ describe("Comprehensive Test Runs with Simulation", () => {
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
 				.withDataStructure(dataStructure)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(manualData)
 				.withEvaluators(localSingleEvaluator, localBooleanEvaluator)
 				.withLogger(logger)
@@ -359,15 +730,15 @@ describe("Comprehensive Test Runs with Simulation", () => {
 
 		test("Prompt + Dataset + Multiple Maxim Evaluators", async () => {
 			const testCase = "prompt-dataset-multiple-maxim";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
-				.withEvaluators("Faithfulness", "Consistency")
+				.withEvaluators("Bias", "Consistency")
 				.withLogger(logger)
 				.run(120);
 
@@ -379,15 +750,15 @@ describe("Comprehensive Test Runs with Simulation", () => {
 
 		test("Prompt + Dataset + Local Combined + Maxim Evaluators", async () => {
 			const testCase = "prompt-dataset-local-combined-maxim";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
-				.withEvaluators(localCombinedEvaluator, "Faithfulness")
+				.withEvaluators(localCombinedEvaluatorForDataset, "Bias")
 				.withLogger(logger)
 				.run(120);
 
@@ -399,13 +770,13 @@ describe("Comprehensive Test Runs with Simulation", () => {
 
 		test("Prompt + Dataset + No evaluators", async () => {
 			const testCase = "prompt-dataset-no-evaluators";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
 				.withLogger(logger)
 				.run(120);
@@ -420,35 +791,15 @@ describe("Comprehensive Test Runs with Simulation", () => {
 	describe("Valid Combinations - Workflow", () => {
 		test("Workflow + Dataset + Local Single Evaluator", async () => {
 			const testCase = "workflow-dataset-local-single";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withWorkflowId(workflowId)
+				.withWorkflowId(workflowId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
-				.withEvaluators(localSingleEvaluator)
-				.withLogger(logger)
-				.run(120);
-
-			expect(result).toBeDefined();
-			expect(result.testRunResult).toBeDefined();
-			expect(result.testRunResult.link).toBeDefined();
-			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
-		}, 3 * 60 * 1000);
-
-		test("Workflow + Dataset + Local Combined Evaluator", async () => {
-			const testCase = "workflow-dataset-local-combined";
-			const logger = new TestLogger(testCase);
-			logger.info("Starting test, Valid Combinations - Prompt Version");
-			const result = await maxim
-				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
-				.withSimulationConfig({ maxTurns: 3 })
-				.withWorkflowId(workflowId)
-				.withData(datasetId)
-				.withEvaluators(localCombinedEvaluator)
+				.withEvaluators(localSingleEvaluatorWithPersona)
 				.withLogger(logger)
 				.run(120);
 
@@ -460,15 +811,15 @@ describe("Comprehensive Test Runs with Simulation", () => {
 
 		test("Workflow + Dataset + Maxim Evaluator", async () => {
 			const testCase = "workflow-dataset-maxim-eval";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withWorkflowId(workflowId)
+				.withWorkflowId(workflowId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
-				.withEvaluators("Faithfulness")
+				.withEvaluators("Bias")
 				.withLogger(logger)
 				.run(120);
 
@@ -486,7 +837,7 @@ describe("Comprehensive Test Runs with Simulation", () => {
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
 				.withDataStructure(dataStructure)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withWorkflowId(workflowId)
+				.withWorkflowId(workflowId, "[SAMPLE] Cosmos context source")
 				.withData(manualData)
 				.withEvaluators(localSingleEvaluator)
 				.withLogger(logger)
@@ -506,9 +857,9 @@ describe("Comprehensive Test Runs with Simulation", () => {
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
 				.withDataStructure(dataStructure)
 				.withSimulationConfig({ maxTurns: 3 })
-				.withWorkflowId(workflowId)
+				.withWorkflowId(workflowId, "[SAMPLE] Cosmos context source")
 				.withData(manualData)
-				.withEvaluators(localSingleEvaluator, "Faithfulness")
+				.withEvaluators(localSingleEvaluator, "Bias")
 				.withLogger(logger)
 				.run(120);
 
@@ -520,19 +871,18 @@ describe("Comprehensive Test Runs with Simulation", () => {
 	});
 
 	describe("Simulation Config Variations", () => {
-		test("Prompt + Dataset + Local Evaluator + Custom Simulation Config", async () => {
-			const testCase = "prompt-dataset-custom-sim-config";
-			const logger = new TestLogger(testCase);
+		test("Prompt + Dataset + Local Evaluator + Simulation Config", async () => {
+			const testCase = "prompt-dataset-minimal-sim-config";
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({
 					maxTurns: 5,
 					scenario: "Test scenario",
-					persona: "Helpful assistant",
 				})
-				.withPromptVersionId(promptVersionId)
+				.withPromptVersionId(promptVersionId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
 				.withEvaluators(localSingleEvaluator)
 				.withLogger(logger)
@@ -546,15 +896,15 @@ describe("Comprehensive Test Runs with Simulation", () => {
 
 		test("Workflow + Dataset + Local Evaluator + Minimal Simulation Config", async () => {
 			const testCase = "workflow-dataset-minimal-sim-config";
-			const logger = new TestLogger(testCase);
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
 			logger.info("Starting test, Valid Combinations - Prompt Version");
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
+				.withDataStructure(dataStructureWithoutPersona)
 				.withSimulationConfig({
 					maxTurns: 2,
 				})
-				.withWorkflowId(workflowId)
+				.withWorkflowId(workflowId, "[SAMPLE] Cosmos context source")
 				.withData(datasetId)
 				.withEvaluators(localSingleEvaluator)
 				.withLogger(logger)
@@ -566,146 +916,371 @@ describe("Comprehensive Test Runs with Simulation", () => {
 			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
 		}, 3 * 60 * 1000);
 	});
+	
+	// ===== LOCAL-EXECUTION SIMULATION TESTS (matching Python test_examples_simulation.py) =====
+	// These tests use the new unified local-execution endpoint with yieldsOutput.
+	// They do NOT require promptVersionId or workflowId.
 
-	// ===== INVALID COMBINATIONS (Error Handling) =====
+	describe("Local-Execution Simulation - Basic (yieldsOutput)", () => {
+		// Matches Python: test_sim_persona_string_manual_data
+		test("Persona as string + manual data + local evaluator", async () => {
+			const testCase = "sim-local-persona-string-manual";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({
+					maxTurns: 4,
+					persona: "You are a curious science student who asks short follow-up questions.",
+				})
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput)
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputBasic)
+				.run(120);
 
-	describe("Invalid Combinations - Error Handling", () => {
-		test("Should fail: Simulation config without prompt or workflow", async () => {
-			const testCase = "invalid-no-prompt-or-workflow";
-			const logger = new TestLogger(testCase);
-			logger.info("Starting test, Valid Combinations - Prompt Version");
-			await expect(
-				maxim
-					.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-					.withDataStructure(dataStructure)
-					.withSimulationConfig({ maxTurns: 3 })
-					.withData(datasetId)
-					.withEvaluators(localSingleEvaluator)
-					.withLogger(logger)
-					.run(120),
-			).rejects.toThrow();
-			console.log(`✅ ${testCase}: Correctly rejected`);
-		});
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
 
-		test("Should fail: Simulation config with yieldsOutput", async () => {
-			const testCase = "invalid-sim-with-yields-output";
-			const logger = new TestLogger(testCase);
-			logger.info("Starting test, Valid Combinations - Prompt Version");
-			await expect(
-				maxim
-					.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-					.withDataStructure(dataStructure)
-					.withSimulationConfig({ maxTurns: 3 })
-					.withData(manualData)
-					.withEvaluators(localSingleEvaluator)
-					.withLogger(logger)
-					.yieldsOutput(async () => ({ data: "test" }))
-					.run(120),
-			).rejects.toThrow();
-			console.log(`✅ ${testCase}: Correctly rejected`);
-		});
+	// 	// Matches Python: test_sim_with_scenario_manual_data
+		test("Scenario from manual data + local evaluator", async () => {
+			const testCase = "sim-local-scenario-manual";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({ maxTurns: 4 })
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput)
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputBasic)
+				.run(120);
 
-		test("Should fail: No data", async () => {
-			const testCase = "invalid-no-data";
-			const logger = new TestLogger(testCase);
-			logger.info("Starting test, Valid Combinations - Prompt Version");
-			await expect(
-				maxim
-					.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-					.withDataStructure(dataStructure)
-					.withSimulationConfig({ maxTurns: 3 })
-					.withPromptVersionId(promptVersionId)
-					.withEvaluators(localSingleEvaluator)
-					.withLogger(logger)
-					.run(120),
-			).rejects.toThrow();
-			console.log(`✅ ${testCase}: Correctly rejected`);
-		});
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
 
-		test("Should fail: Both prompt and workflow", async () => {
-			const testCase = "invalid-both-prompt-workflow";
-			const logger = new TestLogger(testCase);
-			logger.info("Starting test, Valid Combinations - Prompt Version");
-			// Note: This might not throw immediately, but should fail at runtime
-			// The builder might allow this, but the actual run should fail
-			try {
-				await maxim
-					.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-					.withDataStructure(dataStructure)
-					.withSimulationConfig({ maxTurns: 3 })
-					.withPromptVersionId(promptVersionId)
-					.withWorkflowId(workflowId)
-					.withData(datasetId)
-					.withEvaluators(localSingleEvaluator)
-					.withLogger(logger)
-					.run(120);
-				console.log(`⚠️ ${testCase}: Builder allowed both, but should be validated`);
-			} catch (error) {
-				console.log(`✅ ${testCase}: Correctly rejected`);
-			}
-		});
+	// 	// Matches Python: test_sim_no_evaluators_manual_data
+		test("No evaluators + manual data", async () => {
+			const testCase = "sim-local-no-evals-manual";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({ maxTurns: 3 })
+				.withData(manualDataWithInput)
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputBasic)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
+
+	// 	// Matches Python: test_sim_yields_with_context_manual_data
+		test("yields_output with conversation context", async () => {
+			const testCase = "sim-local-yields-context";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({ maxTurns: 4 })
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput)
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputWithContext)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
+
+	// 	// Matches Python: test_sim_stop_trigger_manual_data
+		test("stopTrigger ends simulation early", async () => {
+			const testCase = "sim-local-stop-trigger";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({
+					maxTurns: 10,
+					stopTrigger: { field: "data", value: "STOP" },
+				})
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput)
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputForStop)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
+
+		// Matches Python: test_sim_additional_instructions_manual_data
+		test("additionalInstructions in simulation config", async () => {
+			const testCase = "sim-local-additional-instructions";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({
+					maxTurns: 4,
+					additionalInstructions: "Keep questions brief and focused.",
+				})
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput)
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputBasic)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
+
+		// Matches Python: test_sim_yields_with_llm_manual_data
+		test("yields_output with LLM call (when OPENAI_API_KEY set)", async () => {
+			const testCase = "sim-local-yields-llm";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({ maxTurns: 3 })
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput)
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputWithLlm)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
+
+		// Matches Python: test_sim_with_dataset_id_local_eval
+		test("Dataset ID + local evaluator", async () => {
+			const testCase = "sim-local-dataset-id";
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithoutPersona)
+				.withSimulationConfig({ maxTurns: 3 })
+				.withData(datasetId)
+				.withEvaluators(localEvalWithInput)
+				.withLogger(logger)
+				.yieldsOutput(defaultYieldsOutputWithPersona)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
+
+		// Matches Python: test_sim_local_and_platform_evals_manual_data
+		test("Local + platform evaluators", async () => {
+			const testCase = "sim-local-and-platform-evals";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({ maxTurns: 4 })
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput, "Bias")
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputBasic)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 5 * 60 * 1000);
+
+		// Matches Python: test_sim_simulation_outputs_evaluator_manual_data
+		test("Simulation outputs evaluator", async () => {
+			const testCase = "sim-local-outputs-eval";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
+			const simOutputsEval = createCustomEvaluator<typeof dataStructureWithInput>(
+				"simulation-steps-validator",
+				async (result, data) => {
+					if (!result.simulationOutputs || result.simulationOutputs.length === 0) {
+						return { score: 0, reasoning: "No simulation outputs available" };
+					}
+					const expectedStepsCount = (data["Expected Steps"] ?? "").split("\n").filter((l) => l.trim()).length;
+					const actualStepsCount = result.simulationOutputs.length;
+					return {
+						score: actualStepsCount >= expectedStepsCount ? 1 : 0,
+						reasoning: `Simulation produced ${actualStepsCount} steps, expected ${expectedStepsCount}`,
+					};
+				},
+				{
+					onEachEntry: { scoreShouldBe: ">=", value: 1 },
+					forTestrunOverall: { overallShouldBe: ">=", value: 100, for: "percentageOfPassedResults" },
+				},
+			);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({ maxTurns: 4 })
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput, simOutputsEval)
+				.withLogger(logger)
+				.yieldsOutput(yieldsOutputBasic)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 3 * 60 * 1000);
 	});
 
-	// ===== EDGE CASES =====
-
-	describe("Edge Cases", () => {
-		test("Prompt + Dataset + Boolean Local Evaluator", async () => {
-			const testCase = "prompt-dataset-boolean-eval";
-			const logger = new TestLogger(testCase);
-			logger.info("Starting test, Valid Combinations - Prompt Version");
+	describe("Local-Execution Simulation - Custom Simulator", () => {
+		// Matches Python: test_custom_sim_manual_data_with_local_evals
+		test("Custom simulator + manual data + local evaluators", async () => {
+			const testCase = "custom-sim-manual-local-evals";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
-				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
-				.withData(datasetId)
-				.withEvaluators(localBooleanEvaluator)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({
+					maxTurns: 3,
+					customSimulator: {
+						simulatorPrompt: CUSTOM_SIMULATOR_PROMPT_BASIC,
+						model: "gpt-4o-mini",
+						provider: "openai",
+					},
+				})
+				.withData(manualDataWithInput)
+				.withEvaluators(localEvalWithInput)
 				.withLogger(logger)
+				.yieldsOutput(yieldsOutputWithLlm)
 				.run(120);
 
 			expect(result).toBeDefined();
-			expect(result.testRunResult).toBeDefined();
-			expect(result.testRunResult.link).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
 			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
 		}, 3 * 60 * 1000);
 
-		test("Workflow + Single Manual Data Entry", async () => {
-			const testCase = "workflow-single-manual-entry";
-			const logger = new TestLogger(testCase);
-			logger.info("Starting test, Valid Combinations - Prompt Version");
+		// Matches Python: test_custom_sim_manual_data_no_local_evals
+		test("Custom simulator + manual data + platform evaluator", async () => {
+			const testCase = "custom-sim-manual-platform-eval";
+			const logger = new TestLogger<typeof dataStructureWithInput>(testCase);
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
-				.withSimulationConfig({ maxTurns: 3 })
-				.withWorkflowId(workflowId)
-				.withData([manualData[0]])
-				.withEvaluators(localSingleEvaluator)
+				.withDataStructure(dataStructureWithInput)
+				.withSimulationConfig({
+					maxTurns: 3,
+					customSimulator: {
+						simulatorPrompt: CUSTOM_SIMULATOR_PROMPT_BASIC,
+						model: "gpt-4o-mini",
+						provider: "openai",
+					},
+				})
+				.withData(manualDataWithInput)
+				.withEvaluators("Faithfulness")
 				.withLogger(logger)
+				.yieldsOutput(yieldsOutputWithLlm)
 				.run(120);
 
 			expect(result).toBeDefined();
-			expect(result.testRunResult).toBeDefined();
-			expect(result.testRunResult.link).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 5 * 60 * 1000);
+
+		// Matches Python: test_custom_sim_dataset_id_with_local_evals
+		test("Custom simulator + dataset ID + platform evaluator", async () => {
+			const testCase = "custom-sim-dataset-platform-eval";
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithoutPersona)
+				.withSimulationConfig({
+					maxTurns: 3,
+					customSimulator: {
+						simulatorPrompt: CUSTOM_SIMULATOR_PROMPT_BASIC,
+						model: "gpt-4o-mini",
+						provider: "openai",
+					},
+				})
+				.withData(datasetId)
+				.withEvaluators("Faithfulness")
+				.withLogger(logger)
+				.yieldsOutput(defaultYieldsOutputWithPersona)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
+			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
+		}, 5 * 60 * 1000);
+
+		// Matches Python: test_custom_sim_dataset_id_no_local_evals
+		test("Custom simulator + dataset ID + no evaluators", async () => {
+			const testCase = "custom-sim-dataset-no-evals";
+			const logger = new TestLogger<typeof dataStructureWithoutPersona>(testCase);
+			const result = await maxim
+				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
+				.withDataStructure(dataStructureWithoutPersona)
+				.withSimulationConfig({
+					maxTurns: 3,
+					customSimulator: {
+						simulatorPrompt: CUSTOM_SIMULATOR_PROMPT_BASIC,
+						model: "gpt-4o-mini",
+						provider: "openai",
+					},
+				})
+				.withData(datasetId)
+				.withLogger(logger)
+				.yieldsOutput(defaultYieldsOutputWithPersona)
+				.run(120);
+
+			expect(result).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
 			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
 		}, 3 * 60 * 1000);
 
-		test("Prompt + Dataset + All Evaluator Types Combined", async () => {
-			const testCase = "prompt-dataset-all-eval-types";
-			const logger = new TestLogger(testCase);
-			logger.info("Starting test, Valid Combinations - Prompt Version");
+		// Custom simulator with template variables
+		test("Custom simulator + template variables in prompt", async () => {
+			const testCase = "custom-sim-template-vars";
+			const logger = new TestLogger<typeof dataStructureWithVariables>(testCase);
+			const localEval = createCustomEvaluator<typeof dataStructureWithVariables>(
+				"output-length-validator",
+				async (result) => ({
+					score: result.output.length > 0 ? 1 : 0,
+					reasoning: result.output.length > 0 ? "Has output" : "Empty output",
+				}),
+				{
+					onEachEntry: { scoreShouldBe: ">=", value: 1 },
+					forTestrunOverall: { overallShouldBe: ">=", value: 100, for: "percentageOfPassedResults" },
+				},
+			);
 			const result = await maxim
 				.createTestRun(`SDK Test: ${testCase} - ${Date.now()}`, workspaceId)
-				.withDataStructure(dataStructure)
-				.withSimulationConfig({ maxTurns: 3 })
-				.withPromptVersionId(promptVersionId)
-				.withData(datasetId)
-				.withEvaluators(localSingleEvaluator, simulationOutputsEvaluator)
+				.withDataStructure(dataStructureWithVariables)
+				.withSimulationConfig({
+					maxTurns: 3,
+					customSimulator: {
+						simulatorPrompt: CUSTOM_SIMULATOR_PROMPT_WITH_VARS,
+						model: "gpt-4o-mini",
+						provider: "openai",
+					},
+				})
+				.withData(manualDataWithVariables)
+				.withEvaluators(localEval)
 				.withLogger(logger)
+				.yieldsOutput(async (_data, simCtx) => {
+					if (!simCtx) return { data: "Initial response" };
+					const input = (simCtx.currentUserInput?.["input"] as string) ?? "";
+					return { data: `Turn ${simCtx.turnNumber}: Responding to '${input}'` };
+				})
 				.run(120);
 
 			expect(result).toBeDefined();
-			expect(result.testRunResult).toBeDefined();
-			expect(result.testRunResult.link).toBeDefined();
+			expect(result.testRunResult?.link).toBeDefined();
 			console.log(`✅ ${testCase}: ${result.testRunResult.link}`);
 		}, 3 * 60 * 1000);
 	});

--- a/src/lib/tests/testRuns/testRun.ts
+++ b/src/lib/tests/testRuns/testRun.ts
@@ -1,0 +1,85 @@
+import { createDataStructure } from "src/lib/dataset/dataset";
+import { Maxim } from "../../maxim";
+import "dotenv/config";
+import { Data } from "src/lib/models/dataset";
+import axios from "axios";
+
+
+if (!process.env["MAXIM_API_KEY"]) throw new Error("Missing MAXIM_API_KEY environment variable");
+if (!process.env["MAXIM_WORKSPACE_ID"]) throw new Error("Missing MAXIM_WORKSPACE_ID environment variable");
+if (!process.env["MAXIM_LOG_REPO_ID"]) throw new Error("Missing MAXIM_LOG_REPO_ID environment variable");
+
+const maxim = new Maxim({
+  apiKey: process.env["MAXIM_API_KEY"],
+  baseUrl: process.env["MAXIM_BASE_URL"],
+});
+
+const dataStructure = createDataStructure({
+  Input: "INPUT",
+  "Expected Output": "EXPECTED_OUTPUT",
+  targetLanguage: "VARIABLE",
+  nativeLanguage: "VARIABLE",
+  difficulty: "VARIABLE",
+});
+
+const data = [
+  {
+    Input: "How to say Hello",
+    "Expected Output": "To say \"Hello\" in Spanish, you say \"Hola.\" \n\nCan you try saying it? \nAlso, you can use \"Hola\" in different situations, just like in English! \n\nFor example: \n\n- \"Hola, ¿cómo estás?\" (Hello, how are you?) \n\nWould you like to learn how to respond to that question?",
+    targetLanguage: "Klingon",
+    nativeLanguage: "English",
+    difficulty: "beginner",
+  },
+  {
+    Input: "How to say Good",
+    "Expected Output": "Great question! In Spanish, \"good\" is \"bueno.\" \n\nHere's how you can use it in a sentence:\n\n- \"Es bueno.\" (It is good.)\n- \"El libro es bueno.\" (The book is good.)\n\nCan you try to use \"bueno\" in a sentence",
+    targetLanguage: "Klingon",
+    nativeLanguage: "English",
+    difficulty: "beginner",
+  },
+];
+
+async function main() {
+  const maximLogger = await maxim.logger({ id: process.env["MAXIM_LOG_REPO_ID"]! });
+
+  const testRun = maxim
+    .createTestRun("testing tests + logs", process.env["MAXIM_WORKSPACE_ID"]!)
+    .withDataStructure(dataStructure)
+    .withData(data)
+    .withConcurrency(2)
+    .yieldsOutputWithTracing(async (data: Data<typeof dataStructure>, traceId: string) => {
+      const response = await axios.post("http://localhost:3001/api/v1/chat", {
+        message: data.Input,
+        targetLanguage: data.targetLanguage,
+        nativeLanguage: data.nativeLanguage,
+        difficulty: data.difficulty,
+      }, {
+        headers: {
+          "trace-id": traceId,
+        },
+      });
+
+      const content = response.data.data?.choices[0]?.message?.content || "";
+      const usage = response.data.data?.usage;
+
+      return {
+        data: content,
+        meta: {
+          usage: {
+            totalTokens: usage?.total_tokens || 0,
+            completionTokens: usage?.completion_tokens || 0,
+            promptTokens: usage?.prompt_tokens || 0,
+          },
+          cost: {
+            input: (usage?.prompt_tokens || 0) * 0.0015,
+            output: (usage?.completion_tokens || 0) * 0.002,
+            total: (usage?.total_tokens || 0) * 0.00175,
+          },
+        },
+      };
+    }, maximLogger!, true);
+
+  await testRun.run();
+}
+
+main().catch(console.error);


### PR DESCRIPTION
### TL;DR

Added support for local-execution simulation mode with `yieldsOutput` and `yieldsOutputWithTracing` functions, enabling custom simulator configurations and file attachment handling in test runs.

### What changed?

- **New simulation execution modes**: Added `yieldsOutput` and `yieldsOutputWithTracing` methods to `TestRunBuilder` for local-execution simulation that doesn't require prompt/workflow IDs
- **Custom simulator support**: Introduced `CustomSimulatorConfig` type allowing users to define custom simulator prompts with template variables and model parameters
- **Enhanced simulation context**: Added `SimulationContext` and `SimulationConversationTurn` types to provide conversation history, usage metrics, and turn information to output functions
- **File attachment support**: Implemented file upload pipeline for test run entries, supporting local files, in-memory data, and URL attachments
- **Dependency management**: Moved `axios` and `axios-retry` from dependencies to peerDependencies
- **API enhancements**: Added new endpoints for test run entry creation, simulation status updates, and local-execution simulation
- **Persona resolution**: Enhanced persona handling with priority given to dataset columns over simulation config
- **Stop triggers**: Added support for stopping simulations based on field values or turn limits

### How to test?

1. **Basic local-execution simulation**:
   ```typescript
   maxim.createTestRun("test", workspaceId)
     .withSimulationConfig({ maxTurns: 3 })
     .withData(data)
     .yieldsOutput(async (data, simCtx) => {
       return { data: `Response to: ${simCtx?.currentUserInput}` };
     })
     .run();
   ```

2. **Custom simulator with template variables**:
   ```typescript
   .withSimulationConfig({
     maxTurns: 3,
     customSimulator: {
       simulatorPrompt: "You are {{ persona }}. Ask about {{ topic }}.",
       model: "gpt-4o-mini",
       provider: "openai"
     }
   })
   ```

3. **File attachments in test data**: Use `FileAttachment` or `FileDataAttachment` types in dataset entries

### Why make this change?

This change enables more flexible simulation testing by allowing users to define custom output functions that can interact with their own LLM implementations while still benefiting from Maxim's simulation framework. The local-execution mode provides better control over the conversation flow and enables testing of complex multi-turn scenarios without being tied to specific prompt or workflow configurations. The file attachment support addresses the need to handle various media types in test scenarios.