### PR TITLE
feat: add platform-aware flusing to avoid long delays after stream close

### DIFF
--- a/src/lib/logger/vercel/index.ts
+++ b/src/lib/logger/vercel/index.ts
@@ -6,6 +6,8 @@ import { MaximAISDKWrapper } from "./v1/wrapper";
 import { MaximAISDKWrapperV2 } from "./v2/wrapperV2";
 import { MaximAISDKWrapperV3 } from "./v3/wrapperV3";
 
+export { withMaximLambdaHandler } from "./lambda";
+
 /**
  * Wraps a Vercel AI SDK language model (v1, v2, or v3) with Maxim logging and tracing capabilities.
  *

--- a/src/lib/logger/vercel/lambda.ts
+++ b/src/lib/logger/vercel/lambda.ts
@@ -1,0 +1,160 @@
+import type { AsyncLocalStorage as AsyncLocalStorageType } from "node:async_hooks";
+
+/**
+ * Per-invocation collection of in-flight flush promises.
+ *
+ * The Maxim model wrappers push their background flush promises here (via the
+ * flush-strategy helpers in `./utils`) when a Lambda invocation is being held
+ * open by {@link withMaximLambdaHandler}. The handler wrapper then awaits them
+ * in the window after the response stream closes but before the invocation
+ * completes.
+ */
+export interface MaximFlushStore {
+	pending: Promise<unknown>[];
+}
+
+type FlushALS = AsyncLocalStorageType<MaximFlushStore>;
+
+// `undefined` = not yet resolved, `null` = unavailable on this runtime.
+let flushContext: FlushALS | null | undefined;
+
+/**
+ * Lazily instantiates the `AsyncLocalStorage` used to scope flushes to a single
+ * Lambda invocation.
+ *
+ * `node:async_hooks` is loaded defensively so that importing this module on
+ * runtimes that lack it (edge, react-native) degrades to "no flush window"
+ * rather than throwing at import time.
+ */
+function getFlushContext(): FlushALS | null {
+	if (flushContext !== undefined) {
+		return flushContext;
+	}
+	try {
+		const asyncHooks = require("node:async_hooks") as typeof import("node:async_hooks");
+		flushContext = new asyncHooks.AsyncLocalStorage<MaximFlushStore>();
+	} catch {
+		flushContext = null;
+	}
+	return flushContext;
+}
+
+/**
+ * Returns the flush store for the current Lambda invocation, if one is active
+ * (i.e. the handler is wrapped with {@link withMaximLambdaHandler}). Returns
+ * `undefined` everywhere else, so callers fall through to their default flush
+ * strategy.
+ */
+export function getMaximFlushStore(): MaximFlushStore | undefined {
+	return getFlushContext()?.getStore();
+}
+
+/** Hard ceiling on the post-response flush window, regardless of remaining time. */
+const DEFAULT_FLUSH_CAP_MS = 5000;
+
+/** Safety margin kept below the Lambda deadline so the runtime is never killed mid-flush. */
+const REMAINING_TIME_BUFFER_MS = 1000;
+
+interface LambdaContextLike {
+	getRemainingTimeInMillis?: () => number;
+}
+
+/**
+ * Derives the flush-window cap for this invocation: the smaller of the fixed
+ * ceiling and the remaining Lambda time minus a safety buffer. Reading the
+ * remaining time at drain time (after the handler has run) reflects the real
+ * budget left, so a slow/failing Maxim API can never push the invocation into
+ * a timeout.
+ */
+function computeFlushCapMs(args: unknown[]): number {
+	const ctx = args.find(
+		(a): a is LambdaContextLike =>
+			typeof a === "object" && a !== null && typeof (a as LambdaContextLike).getRemainingTimeInMillis === "function",
+	);
+	const remaining = ctx?.getRemainingTimeInMillis?.();
+	if (typeof remaining === "number" && Number.isFinite(remaining)) {
+		return Math.max(0, Math.min(DEFAULT_FLUSH_CAP_MS, remaining - REMAINING_TIME_BUFFER_MS));
+	}
+	return DEFAULT_FLUSH_CAP_MS;
+}
+
+/**
+ * Awaits the invocation's pending flushes, bounded by `capMs`. Anything not
+ * settled within the cap is left in the writer's retry queue (deferred, not
+ * lost) so the invocation can complete before the Lambda deadline.
+ */
+async function drainPendingFlushes(store: MaximFlushStore, capMs: number): Promise<void> {
+	if (store.pending.length === 0) {
+		return;
+	}
+	if (capMs <= 0) {
+		// No budget left — leave the in-flight flushes to the writer's queue.
+		return;
+	}
+	const settled = Promise.allSettled(store.pending).then(() => undefined);
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const capReached = new Promise<void>((resolve) => {
+		timer = setTimeout(resolve, capMs);
+		timer?.unref?.();
+	});
+	try {
+		await Promise.race([settled, capReached]);
+	} finally {
+		if (timer) {
+			clearTimeout(timer);
+		}
+	}
+}
+
+/**
+ * Wraps an AWS Lambda handler so Maxim can flush telemetry in the window
+ * *after* the response stream closes but *before* the invocation completes
+ * (and the sandbox freezes).
+ *
+ * This requires Lambda **response streaming**: the handler must be passed to
+ * `awslambda.streamifyResponse(...)` and the Function URL configured with
+ * `InvokeMode: RESPONSE_STREAM`. On buffered / API Gateway paths no such window
+ * exists physically, and the SDK's default blocking flush remains correct
+ * (and costs nothing extra, since the response was always going to wait for the
+ * handler to return).
+ *
+ * The flush window is capped (see `DEFAULT_FLUSH_CAP_MS` and the remaining
+ * Lambda time) so a slow or failing Maxim API can never push the invocation
+ * into a timeout. Anything not flushed within the cap stays in the writer's
+ * retry queue.
+ *
+ * Safe by construction: if `node:async_hooks` is unavailable the handler is
+ * returned unchanged, and the model wrappers fall back to their default flush
+ * strategy. If the store cannot be found at flush time (e.g. a library that
+ * drops async context), the wrappers likewise fall through to blocking — the
+ * failure mode is "no improvement", never "lost logs".
+ *
+ * @example
+ * export const handler = awslambda.streamifyResponse(
+ *   withMaximLambdaHandler(async (event, responseStream, context) => {
+ *     // existing handler — unchanged
+ *   }),
+ * );
+ *
+ * @param handler - The Lambda handler to wrap (async).
+ * @returns The wrapped handler with the same signature.
+ */
+export function withMaximLambdaHandler<H extends (...args: any[]) => Promise<unknown>>(handler: H): H {
+	const context = getFlushContext();
+	if (!context) {
+		// No async_hooks on this runtime — cannot open a window; no-op wrapper.
+		return handler;
+	}
+	return (async (...args: Parameters<H>): Promise<unknown> => {
+		const store: MaximFlushStore = { pending: [] };
+		return context.run(store, async () => {
+			try {
+				return await handler(...args);
+			} finally {
+				// Borrowed post-response window: the client already has the full
+				// response; only now do we wait (capped) for telemetry to upload.
+				await drainPendingFlushes(store, computeFlushCapMs(args));
+			}
+		});
+	}) as H;
+}

--- a/src/lib/logger/vercel/utils.ts
+++ b/src/lib/logger/vercel/utils.ts
@@ -2,6 +2,7 @@ import { LanguageModelV1CallOptions, LanguageModelV1ProviderMetadata } from "ai-
 import { LanguageModelV2CallOptions, LanguageModelV2ToolResultOutput, SharedV2ProviderOptions } from "ai-sdk-provider-v2";
 import { LanguageModelV3CallOptions, LanguageModelV3ToolResultOutput, SharedV3ProviderOptions } from "ai-sdk-provider-v3";
 import { v4 as uuid } from "uuid";
+import { getMaximFlushStore } from "./lambda";
 import { MaximVercelProviderMetadata } from "./types";
 
 /**
@@ -138,4 +139,173 @@ export function parseToolResultOutput(content: LanguageModelV2ToolResultOutput |
 		default:
 			throw new Error(`Unknown tool result type: ${content}`);
 	}
+}
+
+type WaitUntil = (promise: Promise<unknown>) => void;
+
+/**
+ * Minimal interface of MaximLogger needed by the flush strategy helpers.
+ * Kept structural to avoid an import cycle with `../logger`.
+ */
+interface FlushableLogger {
+	flush(): Promise<void>;
+}
+
+/**
+ * Returns Vercel's `waitUntil` if running inside a Vercel Function request context.
+ *
+ * Vercel exposes the request context on a well-known global symbol; `waitUntil`
+ * keeps the function alive after the response completes, which is exactly the
+ * window needed to upload telemetry without blocking the response stream.
+ */
+function getVercelWaitUntil(): WaitUntil | undefined {
+	try {
+		const ctx = (globalThis as Record<PropertyKey, unknown>)[Symbol.for("@vercel/request-context") as unknown as string] as
+			| { get?: () => { waitUntil?: WaitUntil } | undefined }
+			| undefined;
+		const waitUntil = ctx?.get?.()?.waitUntil;
+		return typeof waitUntil === "function" ? waitUntil : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+type DeferTask = (fn: () => void | Promise<unknown>) => void;
+
+// `undefined` = not yet resolved, `null` = unavailable on this runtime.
+let expoDeferTask: DeferTask | null | undefined;
+
+/**
+ * Returns Expo server's `deferTask` if the `expo/server` runtime is available.
+ *
+ * `deferTask` runs its callback after the response has been sent and keeps the
+ * request handler alive until it settles — the same post-response window as
+ * Vercel's `waitUntil`, so telemetry uploads without adding response latency.
+ * `expo/server` is an optional peer, loaded defensively (and memoized) so
+ * non-Expo runtimes (where the module is absent) degrade to the next flush
+ * strategy instead of throwing at flush time.
+ */
+function getExpoDeferTask(): DeferTask | undefined {
+	if (expoDeferTask !== undefined) {
+		return expoDeferTask ?? undefined;
+	}
+	try {
+		const expoServer = require("expo/server") as { deferTask?: DeferTask };
+		expoDeferTask = typeof expoServer.deferTask === "function" ? expoServer.deferTask : null;
+	} catch {
+		expoDeferTask = null;
+	}
+	return expoDeferTask ?? undefined;
+}
+
+function isOnAWSLambda(): boolean {
+	return process.env["AWS_LAMBDA_FUNCTION_NAME"] !== undefined;
+}
+
+function safeFlush(logger: FlushableLogger): Promise<void> {
+	return logger.flush().catch((err) => {
+		console.error(`[MaximSDK] Background log flush failed: ${err instanceof Error ? err.message : err}`);
+	});
+}
+
+/**
+ * Flushes logs using an environment-appropriate strategy, never blocking the
+ * caller unless the environment gives no alternative:
+ *
+ * - `withMaximLambdaHandler` active: register the flush on the invocation's
+ *   flush store — the handler wrapper awaits it (capped) in the window after
+ *   the response closes, so nothing blocks here.
+ * - Vercel Functions: hand the flush to `waitUntil` — the runtime keeps the
+ *   function alive after the response finishes, guaranteeing delivery with no
+ *   added response latency.
+ * - Expo server (`expo/server`): hand the flush to `deferTask` — it runs after
+ *   the response is sent and keeps the request handler alive until it settles,
+ *   the same post-response window as Vercel's `waitUntil`.
+ * - AWS Lambda (no `waitUntil` available): await the flush — the sandbox may
+ *   freeze as soon as the response completes, so blocking is the only way to
+ *   guarantee delivery.
+ * - Long-running servers: fire-and-forget — delivery is covered by the
+ *   background flush plus the writer's auto-flush interval and `cleanup()`.
+ */
+export function scheduleLoggerFlush(logger: FlushableLogger): Promise<void> {
+	const flushStore = getMaximFlushStore();
+	if (flushStore) {
+		flushStore.pending.push(safeFlush(logger));
+		return Promise.resolve();
+	}
+	const waitUntil = getVercelWaitUntil();
+	if (waitUntil) {
+		waitUntil(safeFlush(logger));
+		return Promise.resolve();
+	}
+	const deferTask = getExpoDeferTask();
+	if (deferTask) {
+		try {
+			deferTask(() => safeFlush(logger));
+		} catch {
+			// `deferTask` was called outside an Expo request context — fall back to
+			// a background flush so a log is never dropped on the floor.
+			void safeFlush(logger);
+		}
+		return Promise.resolve();
+	}
+	if (isOnAWSLambda()) {
+		return safeFlush(logger);
+	}
+	void safeFlush(logger);
+	return Promise.resolve();
+}
+
+/**
+ * Orders a stream close against the log flush per environment:
+ *
+ * - `withMaximLambdaHandler` active: close first, then register the flush on
+ *   the invocation's flush store — the handler wrapper awaits it (capped) after
+ *   the response closes, so the consumer unblocks immediately and logs are
+ *   still delivered before the sandbox freezes.
+ * - Vercel Functions: close first (consumer unblocks immediately), then flush
+ *   inside `waitUntil`.
+ * - Expo server (`expo/server`): close first, then flush inside `deferTask` —
+ *   it runs after the response is sent and holds the request open until the
+ *   upload settles, so the consumer unblocks immediately and logs still deliver.
+ * - AWS Lambda: flush first, then close — closing ends the response, after
+ *   which the sandbox may freeze before the upload completes.
+ * - Long-running servers: close first, flush in the background.
+ *
+ * `streamText` only emits finish / ends the UI message stream once the model
+ * stream closes, so anything awaited before `close()` directly delays the
+ * consumer.
+ */
+export async function flushAndCloseStream(logger: FlushableLogger, close: () => void): Promise<void> {
+	const flushStore = getMaximFlushStore();
+	if (flushStore) {
+		close();
+		flushStore.pending.push(safeFlush(logger));
+		return;
+	}
+	const waitUntil = getVercelWaitUntil();
+	if (waitUntil) {
+		close();
+		waitUntil(safeFlush(logger));
+		return;
+	}
+	const deferTask = getExpoDeferTask();
+	if (deferTask) {
+		close();
+		try {
+			deferTask(() => safeFlush(logger));
+		} catch {
+			// `deferTask` was called outside an Expo request context — fall back to
+			// a background flush so a log is never dropped on the floor.
+			void safeFlush(logger);
+		}
+		return;
+	}
+	if (isOnAWSLambda()) {
+		await safeFlush(logger);
+		close();
+		return;
+	}
+	close();
+	void safeFlush(logger);
 }

--- a/src/lib/logger/vercel/v1/wrapper.ts
+++ b/src/lib/logger/vercel/v1/wrapper.ts
@@ -1,7 +1,13 @@
 import type { LanguageModelV1, LanguageModelV1CallOptions, LanguageModelV1StreamPart } from "ai-sdk-provider-v1";
 import { MaximLogger } from "../../logger";
 import { v4 as uuid } from "uuid";
-import { determineProvider, extractMaximMetadataFromOptions, extractModelParameters } from "./../utils";
+import {
+	determineProvider,
+	extractMaximMetadataFromOptions,
+	extractModelParameters,
+	flushAndCloseStream,
+	scheduleLoggerFlush,
+} from "./../utils";
 import { Generation, Session, Trace } from "../../components";
 import { ChatCompletionMessage, CompletionRequest } from "src/lib/models/prompt";
 import { convertDoGenerateResultToChatCompletionResult, parsePromptMessages, processStream, processToolResultsFromPromptV1 } from "./utils";
@@ -226,7 +232,8 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 					trace.end();
 				}
 			}
-			await this.logger.flush();
+			// Flush without blocking the caller where the environment allows it
+			await scheduleLoggerFlush(this.logger);
 		}
 	}
 
@@ -320,8 +327,6 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 										}
 									}
 
-									// Flush logs after processStream and tool-result logging complete
-									await wrapperInstance.logger.flush();
 								} catch (error) {
 									console.error("[MaximSDK] Processing failed:", error);
 									if (generation) {
@@ -330,12 +335,13 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 										});
 										generation.end();
 									}
-									// Flush logs even on error
-									await wrapperInstance.logger.flush();
 								}
 
-								// Now close the stream
-								controller.close();
+								// Close the stream and flush logs with environment-appropriate
+								// ordering — consumers (e.g. streamText) are only unblocked once
+								// the stream closes, so the flush must not delay close() unless
+								// the environment leaves no alternative (bare AWS Lambda).
+								await flushAndCloseStream(wrapperInstance.logger, () => controller.close());
 								break;
 							}
 
@@ -357,8 +363,8 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 							});
 							generation.end();
 						}
-						// Flush logs on stream error
-						await wrapperInstance.logger.flush();
+						// Flush logs on stream error (non-blocking where possible)
+						await scheduleLoggerFlush(wrapperInstance.logger);
 					}
 				},
 			});
@@ -379,8 +385,8 @@ export class MaximAISDKWrapper implements LanguageModelV1 {
 			// Log error details
 			console.error("[MaximSDK] doStream failed:", error);
 
-			// Flush logs before throwing error
-			await this.logger.flush();
+			// Flush logs before throwing error (non-blocking where possible)
+			await scheduleLoggerFlush(this.logger);
 
 			throw error;
 		} finally {

--- a/src/lib/logger/vercel/v2/wrapperV2.ts
+++ b/src/lib/logger/vercel/v2/wrapperV2.ts
@@ -1,6 +1,12 @@
 import type { LanguageModelV2, LanguageModelV2CallOptions, LanguageModelV2StreamPart } from "ai-sdk-provider-v2";
 import { MaximLogger } from "../../logger";
-import { determineProvider, extractMaximMetadataFromOptions, extractModelParameters } from "./../utils";
+import {
+	determineProvider,
+	extractMaximMetadataFromOptions,
+	extractModelParameters,
+	flushAndCloseStream,
+	scheduleLoggerFlush,
+} from "./../utils";
 import { Generation, Session, Trace } from "../../components";
 import { v4 as uuid } from "uuid";
 import { ChatCompletionMessage, CompletionRequest, CompletionRequestContent } from "src/lib/models/prompt";
@@ -227,7 +233,8 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 					trace.end();
 				}
 			}
-			await this.logger.flush();
+			// Flush without blocking the caller where the environment allows it
+			await scheduleLoggerFlush(this.logger);
 		}
 	}
 
@@ -322,8 +329,6 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 										}
 									}
 
-									// Flush logs after processStreamV2 and tool-result logging complete
-									await wrapperInstance.logger.flush();
 								} catch (error) {
 									console.error("[MaximSDK] Processing failed:", error);
 									if (generation) {
@@ -332,12 +337,13 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 										});
 										generation.end();
 									}
-									// Flush logs even on error
-									await wrapperInstance.logger.flush();
 								}
 
-								// Now close the stream
-								controller.close();
+								// Close the stream and flush logs with environment-appropriate
+								// ordering — consumers (e.g. streamText) are only unblocked once
+								// the stream closes, so the flush must not delay close() unless
+								// the environment leaves no alternative (bare AWS Lambda).
+								await flushAndCloseStream(wrapperInstance.logger, () => controller.close());
 								break;
 							}
 
@@ -358,8 +364,8 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 							});
 							generation.end();
 						}
-						// Flush logs on stream error
-						await wrapperInstance.logger.flush();
+						// Flush logs on stream error (non-blocking where possible)
+						await scheduleLoggerFlush(wrapperInstance.logger);
 					}
 				},
 			});
@@ -380,8 +386,8 @@ export class MaximAISDKWrapperV2 implements LanguageModelV2 {
 			// Log error details
 			console.error("[MaximSDK] doStream failed:", error);
 
-			// Flush logs before throwing error
-			await this.logger.flush();
+			// Flush logs before throwing error (non-blocking where possible)
+			await scheduleLoggerFlush(this.logger);
 
 			throw error;
 		} finally {

--- a/src/lib/logger/vercel/v3/wrapperV3.ts
+++ b/src/lib/logger/vercel/v3/wrapperV3.ts
@@ -1,6 +1,13 @@
 import type { LanguageModelV3, LanguageModelV3CallOptions, LanguageModelV3StreamPart } from "ai-sdk-provider-v3";
 import { MaximLogger } from "../../logger";
-import { determineProvider, extractErrorInfo, extractMaximMetadataFromOptions, extractModelParameters } from "./../utils";
+import {
+	determineProvider,
+	extractErrorInfo,
+	extractMaximMetadataFromOptions,
+	extractModelParameters,
+	flushAndCloseStream,
+	scheduleLoggerFlush,
+} from "./../utils";
 import { Generation, Session, Trace } from "../../components";
 import { v4 as uuid } from "uuid";
 import { ChatCompletionMessage, CompletionRequest } from "src/lib/models/prompt";
@@ -245,7 +252,8 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 			this.currentTrace = null;
 			this.isInToolCallSequence = false;
 			trace.end();
-			await this.logger.flush();
+			// Flush without blocking the caller where the environment allows it
+			await scheduleLoggerFlush(this.logger);
 		}
 	}
 
@@ -362,21 +370,19 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 									wrapperInstance.currentTrace = null;
 									wrapperInstance.isInToolCallSequence = false;
 									trace.end();
-
-									// Flush logs after processStreamV3 and tool-result logging complete
-									await wrapperInstance.logger.flush();
 								} catch (error) {
 									console.error("[MaximSDK] Processing failed:", error);
 									if (generation) {
 										generation.error(extractErrorInfo(error));
 										generation.end();
 									}
-									// Flush logs even on error
-									await wrapperInstance.logger.flush();
 								}
 
-								// Now close the stream
-								controller.close();
+								// Close the stream and flush logs with environment-appropriate
+								// ordering — consumers (e.g. streamText) are only unblocked once
+								// the stream closes, so the flush must not delay close() unless
+								// the environment leaves no alternative (bare AWS Lambda).
+								await flushAndCloseStream(wrapperInstance.logger, () => controller.close());
 								break;
 							}
 
@@ -395,8 +401,8 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 							generation.error(extractErrorInfo(error));
 							generation.end();
 						}
-						// Flush logs on stream error
-						await wrapperInstance.logger.flush();
+						// Flush logs on stream error (non-blocking where possible)
+						await scheduleLoggerFlush(wrapperInstance.logger);
 					}
 				},
 			});
@@ -415,8 +421,8 @@ export class MaximAISDKWrapperV3 implements LanguageModelV3 {
 			// Log error details
 			console.error("[MaximSDK] doStream failed:", error);
 
-			// Flush logs before throwing error
-			await this.logger.flush();
+			// Flush logs before throwing error (non-blocking where possible)
+			await scheduleLoggerFlush(this.logger);
 
 			throw error;
 		} finally {

--- a/src/lib/tests/vercel/expoDeferTask.e2e.test.ts
+++ b/src/lib/tests/vercel/expoDeferTask.e2e.test.ts
@@ -1,0 +1,215 @@
+/**
+ * E2E harness: Expo server (`expo/server`) flush strategy in the AI SDK wrapper.
+ *
+ * Verifies that when the wrapper runs inside an Expo server request, the log
+ * flush is handed to Expo's `deferTask` — which runs after the response is sent
+ * and keeps the request handler alive until it settles — so the model stream
+ * closes promptly (no user-facing latency) while logs are still delivered.
+ *
+ * `expo/server` is an optional peer that isn't installed in this repo, so it is
+ * mocked virtually here. The mock lives in this dedicated file (not the shared
+ * stream-close-latency suite) because mocking `expo/server` file-wide would
+ * route every flush through `deferTask` and break the Vercel/Lambda cases.
+ *
+ * Run:
+ *   npx jest src/lib/tests/vercel/expoDeferTask.e2e.test.ts --verbose
+ */
+import { streamText, type LanguageModel } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { LanguageModelV3, LanguageModelV3StreamPart, LanguageModelV3Usage } from "ai-sdk-provider-v3";
+
+// ---------------------------------------------------------------------------
+// Mock `expo/server` (virtual — the package isn't a dependency of this repo).
+// `deferTask` simulates Expo holding the request open past the response: it
+// invokes the task immediately and records the promise so the test can await
+// the post-response window (mirrors how the real runtime keeps the handler
+// alive until the deferred task settles).
+// ---------------------------------------------------------------------------
+const mockDeferredTasks: Promise<unknown>[] = [];
+jest.mock(
+	"expo/server",
+	() => ({
+		deferTask: (fn: () => void | Promise<unknown>) => {
+			const result = fn();
+			if (result && typeof (result as Promise<unknown>).then === "function") {
+				mockDeferredTasks.push(result as Promise<unknown>);
+			}
+		},
+	}),
+	{ virtual: true },
+);
+
+// Import AFTER jest.mock so the wrapper's lazy `require("expo/server")` resolves
+// to the mock above.
+import { Maxim } from "../../../../index";
+import { wrapMaximAISDKModel } from "../../../../vercel-ai-sdk";
+import type { MaximLogger } from "../../logger/logger";
+
+jest.setTimeout(120_000);
+
+const FLUSH_DELAY_MS = Number(process.env["MOCK_FLUSH_DELAY_MS"] ?? 3000);
+// A wrapped stream should close within this budget after the last token.
+const CLOSE_BUDGET_MS = Math.min(1000, FLUSH_DELAY_MS / 2);
+
+// ---------------------------------------------------------------------------
+// Mock Maxim API server
+// ---------------------------------------------------------------------------
+
+interface RecordedPush {
+	receivedAt: number;
+	respondedAt: number;
+	body: string;
+}
+
+interface MockMaximServer {
+	baseUrl: string;
+	pushes: RecordedPush[];
+	close: () => Promise<void>;
+}
+
+function startMockMaximServer(pushLogsDelayMs: number): Promise<MockMaximServer> {
+	const pushes: RecordedPush[] = [];
+
+	const server = http.createServer((req, res) => {
+		const bodyChunks: Buffer[] = [];
+		req.on("data", (chunk) => bodyChunks.push(chunk));
+		req.on("end", () => {
+			const body = Buffer.concat(bodyChunks).toString("utf8");
+			const isPushLogs = req.method === "POST" && (req.url ?? "").startsWith("/api/sdk/v3/log");
+
+			if (isPushLogs) {
+				const receivedAt = performance.now();
+				setTimeout(() => {
+					pushes.push({ receivedAt, respondedAt: performance.now(), body });
+					res.writeHead(200, { "Content-Type": "text/plain" });
+					res.end("ok");
+				}, pushLogsDelayMs);
+				return;
+			}
+
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ data: true }));
+		});
+	});
+
+	return new Promise((resolve) => {
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address() as AddressInfo;
+			resolve({
+				baseUrl: `http://127.0.0.1:${port}`,
+				pushes,
+				close: () =>
+					new Promise<void>((res2) => {
+						server.close(() => res2());
+						server.closeAllConnections?.();
+					}),
+			});
+		});
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Mock provider model
+// ---------------------------------------------------------------------------
+
+const MOCK_USAGE: LanguageModelV3Usage = {
+	inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+	outputTokens: { total: 20, text: 20, reasoning: 0 },
+};
+
+function makeStreamingMockModel(): LanguageModelV3 {
+	return new MockLanguageModelV3({
+		doStream: async () => ({
+			stream: simulateReadableStream<LanguageModelV3StreamPart>({
+				chunks: [
+					{ type: "stream-start", warnings: [] },
+					{ type: "text-start", id: "txt-1" },
+					...Array.from(
+						{ length: 20 },
+						(_, i): LanguageModelV3StreamPart => ({ type: "text-delta", id: "txt-1", delta: `token-${i} ` }),
+					),
+					{ type: "text-end", id: "txt-1" },
+					{ type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: MOCK_USAGE },
+				],
+				chunkDelayInMs: 5,
+			}),
+		}),
+	}) as unknown as LanguageModelV3;
+}
+
+// ---------------------------------------------------------------------------
+// Measurement helper
+// ---------------------------------------------------------------------------
+
+interface StreamTiming {
+	lastDeltaToClose: number;
+	total: number;
+	text: string;
+}
+
+async function consumeAndMeasure(model: LanguageModel): Promise<StreamTiming> {
+	const t0 = performance.now();
+	let tLastDelta = t0;
+	let text = "";
+
+	const result = streamText({ model, prompt: "Say hello" });
+	for await (const part of result.fullStream) {
+		if (part.type === "text-delta") {
+			text += part.text;
+			tLastDelta = performance.now();
+		}
+	}
+	const tClosed = performance.now();
+
+	return { lastDeltaToClose: tClosed - tLastDelta, total: tClosed - t0, text };
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe("AI SDK wrapper: Expo server deferTask flush strategy (e2e)", () => {
+	let mockServer: MockMaximServer;
+	let maxim: Maxim;
+	let logger: MaximLogger;
+
+	beforeAll(async () => {
+		mockServer = await startMockMaximServer(FLUSH_DELAY_MS);
+		maxim = new Maxim({ baseUrl: mockServer.baseUrl, apiKey: "e2e-test-key" });
+		const l = await maxim.logger({ id: "e2e-log-repo", flushIntervalSeconds: 3600 });
+		if (!l) throw new Error("Failed to create logger");
+		logger = l;
+	});
+
+	afterAll(async () => {
+		await maxim.cleanup();
+		await mockServer.close();
+	});
+
+	beforeEach(() => {
+		mockServer.pushes.length = 0;
+		mockDeferredTasks.length = 0;
+	});
+
+	it("Expo server: flush is handed to deferTask, stream closes promptly, logs delivered", async () => {
+		const wrapped = wrapMaximAISDKModel(makeStreamingMockModel(), logger);
+		const timing = await consumeAndMeasure(wrapped as unknown as LanguageModel);
+		console.log(
+			`[expo deferTask] lastDelta→close: ${timing.lastDeltaToClose.toFixed(1)}ms, ` +
+				`deferred tasks: ${mockDeferredTasks.length} (flush delay ${FLUSH_DELAY_MS}ms)`,
+		);
+
+		// Stream must close without waiting for the flush.
+		expect(timing.text.length).toBeGreaterThan(0);
+		expect(timing.lastDeltaToClose).toBeLessThan(CLOSE_BUDGET_MS);
+		// The flush must be registered with deferTask (not blocking, not fire-and-forget).
+		expect(mockDeferredTasks.length).toBeGreaterThan(0);
+
+		// Simulate the Expo runtime honoring deferTask before completing the request.
+		await Promise.all(mockDeferredTasks);
+		expect(mockServer.pushes.length).toBeGreaterThan(0);
+		expect(mockServer.pushes[0].body.length).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/tests/vercel/streamCloseLatency.e2e.test.ts
+++ b/src/lib/tests/vercel/streamCloseLatency.e2e.test.ts
@@ -1,0 +1,383 @@
+/**
+ * E2E harness: stream-close latency vs. log delivery in the AI SDK wrapper.
+ *
+ * Reproduces the customer report: with `wrapMaximAISDKModel`, the wrapped
+ * model stream stays open after the provider finishes because the wrapper
+ * awaits `logger.flush()` (an HTTP upload to the Maxim API) before calling
+ * `controller.close()`. `streamText` only emits finish / ends the UI message
+ * stream once the model stream closes, so the chat UI stays in "streaming"
+ * state for the whole flush duration.
+ *
+ * Fully self-contained — no API keys, no external network:
+ *   - Provider:   MockLanguageModelV3 (deterministic token stream)
+ *   - Maxim API:  in-process HTTP server with configurable artificial latency
+ *
+ * Run:
+ *   npx jest src/lib/tests/vercel/streamCloseLatency.e2e.test.ts --verbose
+ *
+ * Knobs:
+ *   MOCK_FLUSH_DELAY_MS  simulated Maxim API latency per pushLogs call (default 3000)
+ *
+ * Expected state:
+ *   - BEFORE the fix: "closes promptly", "generateText", and "waitUntil" tests FAIL
+ *     (close gap ~= MOCK_FLUSH_DELAY_MS), "delivery" tests pass.
+ *   - AFTER the fix: all tests pass (close gap ~ms, logs still delivered).
+ */
+import { generateText, streamText, type LanguageModel } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { LanguageModelV3, LanguageModelV3StreamPart, LanguageModelV3Usage } from "ai-sdk-provider-v3";
+import { Maxim } from "../../../../index";
+import { withMaximLambdaHandler, wrapMaximAISDKModel } from "../../../../vercel-ai-sdk";
+import type { MaximLogger } from "../../logger/logger";
+
+jest.setTimeout(120_000);
+
+const FLUSH_DELAY_MS = Number(process.env["MOCK_FLUSH_DELAY_MS"] ?? 3000);
+// A wrapped stream should close within this budget after the last token.
+// Pre-fix, the close gap is >= FLUSH_DELAY_MS, so this cleanly separates the two.
+const CLOSE_BUDGET_MS = Math.min(1000, FLUSH_DELAY_MS / 2);
+
+const VERCEL_REQUEST_CONTEXT = Symbol.for("@vercel/request-context");
+
+// ---------------------------------------------------------------------------
+// Mock Maxim API server
+// ---------------------------------------------------------------------------
+
+interface RecordedPush {
+	receivedAt: number;
+	respondedAt: number;
+	body: string;
+}
+
+interface MockMaximServer {
+	baseUrl: string;
+	pushes: RecordedPush[];
+	close: () => Promise<void>;
+}
+
+function startMockMaximServer(pushLogsDelayMs: number): Promise<MockMaximServer> {
+	const pushes: RecordedPush[] = [];
+
+	const server = http.createServer((req, res) => {
+		const bodyChunks: Buffer[] = [];
+		req.on("data", (chunk) => bodyChunks.push(chunk));
+		req.on("end", () => {
+			const body = Buffer.concat(bodyChunks).toString("utf8");
+			const isPushLogs = req.method === "POST" && (req.url ?? "").startsWith("/api/sdk/v3/log");
+
+			if (isPushLogs) {
+				const receivedAt = performance.now();
+				// Simulate a slow Maxim ingestion endpoint / bad network conditions
+				setTimeout(() => {
+					pushes.push({ receivedAt, respondedAt: performance.now(), body });
+					res.writeHead(200, { "Content-Type": "text/plain" });
+					res.end("ok");
+				}, pushLogsDelayMs);
+				return;
+			}
+
+			// Everything else (repo-existence check, etc.) responds instantly
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ data: true }));
+		});
+	});
+
+	return new Promise((resolve) => {
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address() as AddressInfo;
+			resolve({
+				baseUrl: `http://127.0.0.1:${port}`,
+				pushes,
+				close: () =>
+					new Promise<void>((res2) => {
+						server.close(() => res2());
+						// Don't let in-flight sockets hold the server open
+						server.closeAllConnections?.();
+					}),
+			});
+		});
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Mock provider model
+// ---------------------------------------------------------------------------
+
+const MOCK_USAGE: LanguageModelV3Usage = {
+	inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+	outputTokens: { total: 20, text: 20, reasoning: 0 },
+};
+
+function makeStreamingMockModel(): LanguageModelV3 {
+	return new MockLanguageModelV3({
+		doStream: async () => ({
+			stream: simulateReadableStream<LanguageModelV3StreamPart>({
+				chunks: [
+					{ type: "stream-start", warnings: [] },
+					{ type: "text-start", id: "txt-1" },
+					...Array.from(
+						{ length: 20 },
+						(_, i): LanguageModelV3StreamPart => ({ type: "text-delta", id: "txt-1", delta: `token-${i} ` }),
+					),
+					{ type: "text-end", id: "txt-1" },
+					{ type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: MOCK_USAGE },
+				],
+				chunkDelayInMs: 5,
+			}),
+		}),
+	}) as unknown as LanguageModelV3;
+}
+
+function makeGenerateMockModel(): LanguageModelV3 {
+	return new MockLanguageModelV3({
+		doGenerate: async () => ({
+			content: [{ type: "text", text: "Hello from the mock model!" }],
+			finishReason: { unified: "stop", raw: "stop" },
+			usage: MOCK_USAGE,
+			warnings: [],
+		}),
+	}) as unknown as LanguageModelV3;
+}
+
+// ---------------------------------------------------------------------------
+// Measurement helpers
+// ---------------------------------------------------------------------------
+
+interface StreamTiming {
+	/** ms between the last text-delta part and stream close (loop exit) */
+	lastDeltaToClose: number;
+	/** ms between the finish part and stream close (loop exit) */
+	finishToClose: number;
+	/** total wall time of the stream consumption */
+	total: number;
+	text: string;
+}
+
+async function consumeAndMeasure(model: LanguageModel): Promise<StreamTiming> {
+	const t0 = performance.now();
+	let tLastDelta = t0;
+	let tFinishPart = t0;
+	let text = "";
+
+	const result = streamText({ model, prompt: "Say hello" });
+	for await (const part of result.fullStream) {
+		if (part.type === "text-delta") {
+			text += part.text;
+			tLastDelta = performance.now();
+		}
+		if (part.type === "finish") {
+			tFinishPart = performance.now();
+		}
+	}
+	// The for-await loop only exits once the underlying stream CLOSES —
+	// this is the moment `streamText` unblocks the UI message stream.
+	const tClosed = performance.now();
+
+	return {
+		lastDeltaToClose: tClosed - tLastDelta,
+		finishToClose: tClosed - tFinishPart,
+		total: tClosed - t0,
+		text,
+	};
+}
+
+async function waitFor(cond: () => boolean, timeoutMs: number, label: string): Promise<void> {
+	const start = Date.now();
+	while (!cond()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error(`Timed out after ${timeoutMs}ms waiting for: ${label}`);
+		}
+		await new Promise((r) => setTimeout(r, 50));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AI SDK wrapper: stream-close latency vs. log delivery (e2e)", () => {
+	let mockServer: MockMaximServer;
+	let maxim: Maxim;
+	let logger: MaximLogger;
+
+	beforeAll(async () => {
+		mockServer = await startMockMaximServer(FLUSH_DELAY_MS);
+		maxim = new Maxim({
+			baseUrl: mockServer.baseUrl,
+			apiKey: "e2e-test-key",
+		});
+		const l = await maxim.logger({ id: "e2e-log-repo", flushIntervalSeconds: 3600 });
+		if (!l) throw new Error("Failed to create logger");
+		logger = l;
+	});
+
+	afterAll(async () => {
+		await maxim.cleanup();
+		await mockServer.close();
+	});
+
+	beforeEach(() => {
+		mockServer.pushes.length = 0;
+	});
+
+	it("baseline: raw (unwrapped) mock model closes immediately after finish", async () => {
+		const timing = await consumeAndMeasure(makeStreamingMockModel() as unknown as LanguageModel);
+		console.log(
+			`[baseline raw] finish→close: ${timing.finishToClose.toFixed(1)}ms, ` +
+				`lastDelta→close: ${timing.lastDeltaToClose.toFixed(1)}ms, total: ${timing.total.toFixed(1)}ms`,
+		);
+		expect(timing.text.length).toBeGreaterThan(0);
+		expect(timing.lastDeltaToClose).toBeLessThan(CLOSE_BUDGET_MS);
+	});
+
+	it("wrapped model stream closes promptly after finish (customer-reported bug)", async () => {
+		const wrapped = wrapMaximAISDKModel(makeStreamingMockModel(), logger);
+		const timing = await consumeAndMeasure(wrapped as unknown as LanguageModel);
+		console.log(
+			`[wrapped] finish→close: ${timing.finishToClose.toFixed(1)}ms, ` +
+				`lastDelta→close: ${timing.lastDeltaToClose.toFixed(1)}ms, total: ${timing.total.toFixed(1)}ms ` +
+				`(mock Maxim API latency: ${FLUSH_DELAY_MS}ms)`,
+		);
+		expect(timing.text.length).toBeGreaterThan(0);
+		// PRE-FIX: this fails — close is delayed by ~FLUSH_DELAY_MS because the
+		// wrapper awaits logger.flush() before controller.close().
+		expect(timing.lastDeltaToClose).toBeLessThan(CLOSE_BUDGET_MS);
+	});
+
+	it("wrapped model still delivers logs to the Maxim API after streaming", async () => {
+		const wrapped = wrapMaximAISDKModel(makeStreamingMockModel(), logger);
+		await consumeAndMeasure(wrapped as unknown as LanguageModel);
+		const tClosed = performance.now();
+
+		// Logs must arrive regardless of whether the flush is blocking (pre-fix)
+		// or backgrounded (post-fix).
+		await waitFor(() => mockServer.pushes.length > 0, FLUSH_DELAY_MS + 10_000, "pushLogs to reach mock Maxim API");
+		const arrival = mockServer.pushes[0].respondedAt - tClosed;
+		console.log(`[delivery] pushLogs completed ${arrival.toFixed(1)}ms after stream close; payload bytes: ${mockServer.pushes[0].body.length}`);
+		expect(mockServer.pushes[0].body.length).toBeGreaterThan(0);
+	});
+
+	it("wrapped generateText (doGenerate) returns without blocking on flush", async () => {
+		const wrapped = wrapMaximAISDKModel(makeGenerateMockModel(), logger);
+		const t0 = performance.now();
+		const result = await generateText({ model: wrapped as unknown as LanguageModel, prompt: "Say hello" });
+		const wallTime = performance.now() - t0;
+		console.log(`[generateText] wall time: ${wallTime.toFixed(1)}ms (mock Maxim API latency: ${FLUSH_DELAY_MS}ms)`);
+		expect(result.text.length).toBeGreaterThan(0);
+		// PRE-FIX: this fails — doGenerate's finally awaits logger.flush().
+		expect(wallTime).toBeLessThan(CLOSE_BUDGET_MS);
+
+		// ...but delivery must still happen in the background.
+		await waitFor(() => mockServer.pushes.length > 0, FLUSH_DELAY_MS + 10_000, "pushLogs to reach mock Maxim API");
+	});
+
+	it("Vercel environment: flush is handed to waitUntil, stream closes promptly, logs delivered", async () => {
+		const captured: Promise<unknown>[] = [];
+		(globalThis as Record<PropertyKey, unknown>)[VERCEL_REQUEST_CONTEXT as unknown as string] = {
+			get: () => ({
+				waitUntil: (p: Promise<unknown>) => {
+					captured.push(p);
+				},
+			}),
+		};
+
+		try {
+			const wrapped = wrapMaximAISDKModel(makeStreamingMockModel(), logger);
+			const timing = await consumeAndMeasure(wrapped as unknown as LanguageModel);
+			console.log(
+				`[waitUntil] finish→close: ${timing.finishToClose.toFixed(1)}ms, ` +
+					`lastDelta→close: ${timing.lastDeltaToClose.toFixed(1)}ms, waitUntil promises: ${captured.length}`,
+			);
+
+			// Stream must close without waiting for the flush
+			expect(timing.lastDeltaToClose).toBeLessThan(CLOSE_BUDGET_MS);
+			// PRE-FIX: fails — the wrapper never registers the flush with waitUntil.
+			expect(captured.length).toBeGreaterThan(0);
+
+			// Simulate the serverless runtime honoring waitUntil before freezing
+			await Promise.all(captured);
+			expect(mockServer.pushes.length).toBeGreaterThan(0);
+		} finally {
+			delete (globalThis as Record<PropertyKey, unknown>)[VERCEL_REQUEST_CONTEXT as unknown as string];
+		}
+	});
+
+	it("bare AWS Lambda (no waitUntil): flush completes BEFORE stream close to survive sandbox freeze", async () => {
+		process.env["AWS_LAMBDA_FUNCTION_NAME"] = "e2e-test-fn";
+		try {
+			const wrapped = wrapMaximAISDKModel(makeStreamingMockModel(), logger);
+			const timing = await consumeAndMeasure(wrapped as unknown as LanguageModel);
+			console.log(
+				`[lambda] lastDelta→close: ${timing.lastDeltaToClose.toFixed(1)}ms, pushes at close: ${mockServer.pushes.length}`,
+			);
+			// On bare Lambda blocking is intentional — delivery must already be
+			// complete by the time the stream closes (sandbox may freeze after).
+			expect(mockServer.pushes.length).toBeGreaterThan(0);
+			expect(timing.lastDeltaToClose).toBeGreaterThanOrEqual(FLUSH_DELAY_MS * 0.9);
+		} finally {
+			delete process.env["AWS_LAMBDA_FUNCTION_NAME"];
+		}
+	});
+
+	it("withMaximLambdaHandler: stream closes promptly, flush drained in the post-response window", async () => {
+		// Set the Lambda env so we also prove the ALS flush store takes precedence
+		// over the plain Lambda-blocking branch.
+		process.env["AWS_LAMBDA_FUNCTION_NAME"] = "e2e-test-fn";
+		try {
+			const wrapped = wrapMaximAISDKModel(makeStreamingMockModel(), logger);
+			let timing!: StreamTiming;
+			// Generous remaining time → cap = min(5s, remaining - 1s) does not bite.
+			const ctx = { getRemainingTimeInMillis: () => 60_000 };
+			const handler = withMaximLambdaHandler(async (_event: unknown, _responseStream: unknown, _ctx: unknown) => {
+				timing = await consumeAndMeasure(wrapped as unknown as LanguageModel);
+				return timing;
+			});
+
+			const t0 = performance.now();
+			await handler({}, {}, ctx);
+			const handlerWall = performance.now() - t0;
+
+			console.log(
+				`[withMaximLambdaHandler] lastDelta→close: ${timing.lastDeltaToClose.toFixed(1)}ms, ` +
+					`handler wall: ${handlerWall.toFixed(1)}ms, pushes: ${mockServer.pushes.length} (flush delay ${FLUSH_DELAY_MS}ms)`,
+			);
+
+			// Stream closes promptly — the ALS store branch closes before flushing,
+			// unlike the plain Lambda-blocking branch.
+			expect(timing.lastDeltaToClose).toBeLessThan(CLOSE_BUDGET_MS);
+			// ...but the handler does not resolve until the flush has drained, so the
+			// sandbox will not freeze before delivery.
+			expect(mockServer.pushes.length).toBeGreaterThan(0);
+			expect(handlerWall).toBeGreaterThanOrEqual(FLUSH_DELAY_MS * 0.9);
+		} finally {
+			delete process.env["AWS_LAMBDA_FUNCTION_NAME"];
+		}
+	});
+
+	it("withMaximLambdaHandler: flush window is capped by remaining Lambda time (never eats the timeout)", async () => {
+		process.env["AWS_LAMBDA_FUNCTION_NAME"] = "e2e-test-fn";
+		try {
+			const wrapped = wrapMaximAISDKModel(makeStreamingMockModel(), logger);
+			const handler = withMaximLambdaHandler(async (_event: unknown, _responseStream: unknown, _ctx: unknown) => {
+				await consumeAndMeasure(wrapped as unknown as LanguageModel);
+			});
+			// Remaining time forces cap = max(0, min(5000, 1200 - 1000)) = 200ms,
+			// well below the 3000ms mock flush — the drain must give up at the cap.
+			const ctx = { getRemainingTimeInMillis: () => 1200 };
+
+			const t0 = performance.now();
+			await handler({}, {}, ctx);
+			const handlerWall = performance.now() - t0;
+
+			console.log(`[withMaximLambdaHandler cap] handler wall: ${handlerWall.toFixed(1)}ms (flush delay ${FLUSH_DELAY_MS}ms)`);
+
+			// The drain returns near the cap rather than waiting the full flush, so a
+			// slow/failing Maxim API can never push the invocation past its deadline.
+			expect(handlerWall).toBeLessThan(FLUSH_DELAY_MS * 0.9);
+		} finally {
+			delete process.env["AWS_LAMBDA_FUNCTION_NAME"];
+		}
+	});
+});

--- a/vercel-ai-sdk.ts
+++ b/vercel-ai-sdk.ts
@@ -1,2 +1,2 @@
 export type { MaximVercelProviderMetadata } from "./src/lib/logger/vercel/types";
-export { wrapMaximAISDKModel } from "./src/lib/logger/vercel";
+export { withMaximLambdaHandler, wrapMaximAISDKModel } from "./src/lib/logger/vercel";


### PR DESCRIPTION
### TL;DR

Fixes a customer-reported bug where the Maxim-wrapped AI SDK model stream stayed open after the provider finished streaming, because `logger.flush()` was awaited before `controller.close()`. Introduces environment-aware flush scheduling and a new `withMaximLambdaHandler` wrapper for AWS Lambda response streaming.

### What changed?

- **`withMaximLambdaHandler`** (`src/lib/logger/vercel/lambda.ts`): A new exported wrapper for AWS Lambda handlers that opens a post-response flush window using `AsyncLocalStorage`. After the handler's response stream closes, it awaits pending Maxim telemetry flushes in a capped window (bounded by `DEFAULT_FLUSH_CAP_MS` and the remaining Lambda invocation time minus a safety buffer). If `node:async_hooks` is unavailable, the handler is returned unchanged.

- **`scheduleLoggerFlush` and `flushAndCloseStream`** (`src/lib/logger/vercel/utils.ts`): Two new helpers that replace direct `logger.flush()` calls throughout the v1/v2/v3 wrappers. They select the appropriate flush strategy based on the runtime environment:
  - **`withMaximLambdaHandler` active**: registers the flush on the invocation's `MaximFlushStore` — the handler drains it after the response closes.
  - **Vercel Functions**: hands the flush to `waitUntil` so the response is never delayed.
  - **Bare AWS Lambda**: awaits the flush before closing, since the sandbox may freeze immediately after the response.
  - **Long-running servers**: fire-and-forget, relying on the background flush interval.

  `flushAndCloseStream` additionally controls the ordering of `controller.close()` relative to the flush — on all environments except bare Lambda, the stream closes first so consumers (e.g. `streamText`) are unblocked immediately.

- **v1/v2/v3 wrappers**: All direct `await this.logger.flush()` calls replaced with `scheduleLoggerFlush` or `flushAndCloseStream` as appropriate.

- **`withMaximLambdaHandler`** is now exported from `vercel-ai-sdk.ts` as a public API.

### How to test?

An end-to-end test suite is included at `src/lib/tests/vercel/streamCloseLatency.e2e.test.ts`. It uses a fully self-contained in-process mock Maxim API server with configurable artificial latency and a `MockLanguageModelV3` provider. Run it with:

```
npx jest src/lib/tests/vercel/streamCloseLatency.e2e.test.ts --verbose
```

The `MOCK_FLUSH_DELAY_MS` environment variable controls the simulated Maxim API latency (default `3000`ms). The tests cover:
- Raw (unwrapped) model closes immediately as a baseline.
- Wrapped streaming model closes promptly after the last token.
- Logs are still delivered to the Maxim API after streaming completes.
- `generateText` (`doGenerate`) returns without blocking on the flush.
- Vercel `waitUntil` path: stream closes promptly and the flush promise is registered.
- Bare Lambda path: flush completes before stream close.
- `withMaximLambdaHandler` path: stream closes promptly, flush drains in the post-response window.
- `withMaximLambdaHandler` cap: a tight remaining-time budget causes the drain to give up before the full flush delay, preventing timeout.

### Why make this change?

Previously, all flush calls in the AI SDK wrappers were unconditional `await logger.flush()` calls placed before `controller.close()`. Because `streamText` only emits `finish` and ends the UI message stream once the underlying model stream closes, any latency in the Maxim API (network slowness, retries) was directly added to the user-visible streaming response time. On serverless runtimes like AWS Lambda, simply moving the flush after `close()` is not safe because the sandbox can freeze before the upload completes. The new environment-aware strategy eliminates response latency on Vercel and Lambda streaming while preserving delivery guarantees on each platform.