### PR TITLE
feat: add AI SDK v7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"ai-sdk-provider-v1": "npm:@ai-sdk/provider@^1.0.0",
 		"ai-sdk-provider-v2": "npm:@ai-sdk/provider@^2.0.0",
 		"ai-sdk-provider-v3": "npm:@ai-sdk/provider@^3.0.0",
+		"ai-sdk-provider-v4": "npm:@ai-sdk/provider@^4.0.0",
 		"copyfiles": "2.4.1",
 		"dotenv": "^16.5.0",
 		"eslint": "9.28.0",
@@ -58,10 +59,10 @@
 	},
 	"peerDependencies": {
 		"@types/mime-types": "3.0.1",
-		"expo-crypto": "^13.0.0",
-		"mime-types": "3.0.1",
 		"axios": "^1.11.0",
-		"axios-retry": "^4.5.0"
+		"axios-retry": "^4.5.0",
+		"expo-crypto": "^13.0.0",
+		"mime-types": "3.0.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/src/lib/logger/vercel/index.ts
+++ b/src/lib/logger/vercel/index.ts
@@ -1,10 +1,12 @@
 import { LanguageModelV1 } from "ai-sdk-provider-v1";
 import { LanguageModelV2 } from "ai-sdk-provider-v2";
 import { LanguageModelV3 } from "ai-sdk-provider-v3";
+import { LanguageModelV4 } from "ai-sdk-provider-v4";
 import { MaximLogger } from "../logger";
 import { MaximAISDKWrapper } from "./v1/wrapper";
 import { MaximAISDKWrapperV2 } from "./v2/wrapperV2";
 import { MaximAISDKWrapperV3 } from "./v3/wrapperV3";
+import { MaximAISDKWrapperV4 } from "./v4/wrapperV4";
 
 export { withMaximLambdaHandler } from "./lambda";
 
@@ -16,12 +18,15 @@ export { withMaximLambdaHandler } from "./lambda";
  * trace logging, generation tracking, and attachment handling. If the model specification
  * is not supported, it logs an error and returns the original model.
  *
- * @template T - The type of the language model (must extend LanguageModelV1, LanguageModelV2, or LanguageModelV3).
- * @param model - The Vercel AI SDK language model instance to wrap (supports v1, v2, and v3 specifications).
+ * @template T - The type of the language model (must extend LanguageModelV1, LanguageModelV2, LanguageModelV3, or LanguageModelV4).
+ * @param model - The Vercel AI SDK language model instance to wrap (supports v1, v2, v3, and v4 specifications).
  * @param logger - The MaximLogger instance to use for tracing and logging.
  * @returns The wrapped model with Maxim integration, or the original model if the specification version is unsupported.
  */
-export function wrapMaximAISDKModel<T extends LanguageModelV1 | LanguageModelV2 | LanguageModelV3>(model: T, logger: MaximLogger): T {
+export function wrapMaximAISDKModel<T extends LanguageModelV1 | LanguageModelV2 | LanguageModelV3 | LanguageModelV4>(
+	model: T,
+	logger: MaximLogger,
+): T {
 	if (model?.specificationVersion === "v1") {
 		return new MaximAISDKWrapper(model, logger) as unknown as T;
 	}
@@ -30,6 +35,9 @@ export function wrapMaximAISDKModel<T extends LanguageModelV1 | LanguageModelV2 
 	}
 	if (model?.specificationVersion === "v3") {
 		return new MaximAISDKWrapperV3(model, logger) as unknown as T;
+	}
+	if (model?.specificationVersion === "v4") {
+		return new MaximAISDKWrapperV4(model, logger) as unknown as T;
 	}
 	console.error("[MaximSDK] Unsupported model");
 	return model;

--- a/src/lib/logger/vercel/utils.ts
+++ b/src/lib/logger/vercel/utils.ts
@@ -1,6 +1,7 @@
 import { LanguageModelV1CallOptions, LanguageModelV1ProviderMetadata } from "ai-sdk-provider-v1";
 import { LanguageModelV2CallOptions, LanguageModelV2ToolResultOutput, SharedV2ProviderOptions } from "ai-sdk-provider-v2";
 import { LanguageModelV3CallOptions, LanguageModelV3ToolResultOutput, SharedV3ProviderOptions } from "ai-sdk-provider-v3";
+import { LanguageModelV4CallOptions, LanguageModelV4ToolResultOutput, SharedV4ProviderOptions } from "ai-sdk-provider-v4";
 import { v4 as uuid } from "uuid";
 import { getMaximFlushStore } from "./lambda";
 import { MaximVercelProviderMetadata } from "./types";
@@ -50,7 +51,9 @@ export function determineProvider(
  * @param options - The call options containing model parameters.
  * @returns An object containing the extracted model parameters, including temperature, maxTokens, topP, topK, frequencyPenalty, stopSequences, seed, headers, presencePenalty, abortSignal, and responseFormat.
  */
-export function extractModelParameters(options: LanguageModelV1CallOptions | LanguageModelV2CallOptions | LanguageModelV3CallOptions) {
+export function extractModelParameters(
+	options: LanguageModelV1CallOptions | LanguageModelV2CallOptions | LanguageModelV3CallOptions | LanguageModelV4CallOptions,
+) {
 	const params = {
 		temperature: options.temperature,
 		topP: options.topP,
@@ -75,7 +78,7 @@ export function extractModelParameters(options: LanguageModelV1CallOptions | Lan
  * @returns The extracted Maxim metadata with a guaranteed `spanId`, or undefined if not present.
  */
 export function extractMaximMetadataFromOptions(
-	metadata: LanguageModelV1ProviderMetadata | SharedV2ProviderOptions | SharedV3ProviderOptions | undefined,
+	metadata: LanguageModelV1ProviderMetadata | SharedV2ProviderOptions | SharedV3ProviderOptions | SharedV4ProviderOptions | undefined,
 ) {
 	if (!metadata || !metadata["maxim"]) return undefined;
 	const maximMetadata = metadata["maxim"] as MaximVercelProviderMetadata;
@@ -127,7 +130,9 @@ export function extractErrorInfo(error: unknown): { message: string; code?: stri
 	return { message: String(error) };
 }
 
-export function parseToolResultOutput(content: LanguageModelV2ToolResultOutput | LanguageModelV3ToolResultOutput): string {
+export function parseToolResultOutput(
+	content: LanguageModelV2ToolResultOutput | LanguageModelV3ToolResultOutput | LanguageModelV4ToolResultOutput,
+): string {
 	switch (content.type) {
 		case "text":
 		case "error-text":
@@ -136,8 +141,11 @@ export function parseToolResultOutput(content: LanguageModelV2ToolResultOutput |
 		case "error-json":
 		case "content":
 			return JSON.stringify(content.value);
+		// v4 introduces `execution-denied` for tool calls the user declined to run
+		case "execution-denied":
+			return content.reason ?? "Tool execution denied";
 		default:
-			throw new Error(`Unknown tool result type: ${content}`);
+			throw new Error(`Unknown tool result type: ${JSON.stringify(content)}`);
 	}
 }
 

--- a/src/lib/logger/vercel/v4/utils.ts
+++ b/src/lib/logger/vercel/v4/utils.ts
@@ -1,0 +1,457 @@
+import {
+	LanguageModelV4GenerateResult,
+	LanguageModelV4Prompt,
+	LanguageModelV4StreamPart,
+	LanguageModelV4ToolCall,
+} from "ai-sdk-provider-v4";
+import {
+	ChatCompletionChoice,
+	ChatCompletionMessage,
+	ChatCompletionResult,
+	CompletionRequest,
+	CompletionRequestContent,
+	Generation,
+	Span,
+	Trace,
+} from "index";
+import type { MaximLogger } from "../../logger";
+import type { ToolCallError } from "../../components/toolCall";
+import { extractErrorInfo, parseToolResultOutput } from "../utils";
+import { v4 as uuid } from "uuid";
+import { MaximVercelProviderMetadata } from "../types";
+import type { Attachment, FileDataAttachment, UrlAttachment } from "../../../types";
+
+/**
+ * Decodes a base64 (or `data:` URI) string into a Buffer.
+ *
+ * AI SDK v4 file parts carry inline bytes as either a raw Uint8Array or a
+ * base64-encoded string (optionally wrapped in a `data:...;base64,` URI). This
+ * normalizes the string form into a Buffer for attachment handling.
+ *
+ * @param data - The base64 string, optionally with a data URI prefix.
+ * @returns The decoded file bytes.
+ */
+function decodeBase64FileData(data: string): Buffer {
+	if (data.startsWith("data:")) {
+		const match = data.match(/^data:([^;]+);base64,(.+)$/);
+		if (match) {
+			return Buffer.from(match[2], "base64");
+		}
+	}
+	// Assume it's already base64 without the data URI prefix
+	return Buffer.from(data, "base64");
+}
+
+/**
+ * Derives a file extension from an IANA media type, defaulting to `bin`.
+ *
+ * @param mediaType - The IANA media type (e.g. `image/png`) or undefined.
+ * @returns The subtype used as a file extension, or `bin` if not derivable.
+ */
+function extensionFromMediaType(mediaType: string | undefined): string {
+	const mediaTypeParts = mediaType?.split("/") || [];
+	return mediaTypeParts[1]?.split(";")[0] || "bin";
+}
+
+/**
+ * Renders a generated v4 file part's data as a loggable string.
+ *
+ * v4 file data is a tagged union: a URL, or inline bytes (`Uint8Array`) /
+ * base64 string. `String(uint8array)` would yield unusable comma-separated
+ * digits ("137,80,78,..."), so raw bytes are base64-encoded instead.
+ *
+ * @param data - The file part's `data` (URL or inline-data variant).
+ * @returns A URL string, the base64 string as-is, or base64 of the raw bytes.
+ */
+function renderFileContent(data: { type: "url"; url: URL } | { type: "data"; data: Uint8Array | string }): string {
+	if (data.type === "url") {
+		return data.url.toString();
+	}
+	return typeof data.data === "string" ? data.data : Buffer.from(data.data).toString("base64");
+}
+
+/**
+ * Converts a LanguageModelV4Prompt into an array of CompletionRequest or ChatCompletionMessage objects.
+ *
+ * This function transforms the structured prompt format used by the Vercel AI SDK v4 (AI SDK 7) into the message format expected by downstream consumers, handling system, user, assistant, and tool roles.
+ * It also extracts file attachments from file messages.
+ *
+ * Note: unlike v3, v4 file parts carry their payload as a tagged discriminated
+ * union (`{ type: 'data' | 'url' | 'text' | 'reference' }`) rather than a bare
+ * `Uint8Array | string | URL`, so file handling switches on `data.type`.
+ *
+ * @param prompt - The prompt to be parsed, consisting of structured message parts.
+ * @returns An object containing parsed messages and extracted file attachments.
+ * @throws If an unsupported user message type is encountered.
+ */
+export function parsePromptMessagesV4(
+	prompt: LanguageModelV4Prompt,
+): {
+	messages: Array<CompletionRequest | ChatCompletionMessage>;
+	attachments: Attachment[];
+} {
+	const attachments: Attachment[] = [];
+	const promptMessages: Array<CompletionRequest | ChatCompletionMessage> = prompt
+		.map((promptMsg) => {
+			switch (promptMsg.role) {
+				case "system": {
+					return [
+						{
+							role: "system",
+							content: promptMsg.content,
+						},
+					] as Array<CompletionRequest | ChatCompletionMessage>;
+				}
+				case "user": {
+					const contentItems: CompletionRequestContent[] = [];
+
+					for (const msg of promptMsg.content) {
+						switch (msg.type) {
+							case "text":
+								contentItems.push({
+									type: "text",
+									text: msg.text,
+								});
+								break;
+							case "file": {
+								// v4 file data is a tagged discriminated union
+								const fileData = msg.data;
+								switch (fileData.type) {
+									case "url": {
+										attachments.push({
+											id: uuid(),
+											type: "url",
+											url: fileData.url.toString(),
+											mimeType: msg.mediaType,
+											tags: { attachedTo: "input" },
+										} as UrlAttachment);
+										break;
+									}
+									case "data": {
+										// Raw bytes (Uint8Array) or a base64-encoded string
+										const buffer =
+											typeof fileData.data === "string"
+												? decodeBase64FileData(fileData.data)
+												: Buffer.from(fileData.data);
+										const extension = extensionFromMediaType(msg.mediaType);
+										attachments.push({
+											id: uuid(),
+											type: "fileData",
+											data: buffer,
+											mimeType: msg.mediaType,
+											name: `file.${extension}`,
+											tags: { attachedTo: "input" },
+										} as FileDataAttachment);
+										break;
+									}
+									case "text": {
+										// Inline text document — surface it as message text rather than an attachment
+										contentItems.push({
+											type: "text",
+											text: fileData.text,
+										});
+										break;
+									}
+									case "reference": {
+										// Provider-side reference with no downloadable payload — nothing to attach
+										break;
+									}
+									default:
+										break;
+								}
+								break;
+							}
+							default:
+								throw new Error(`Unsupported user message type: ${msg}`);
+						}
+					}
+
+					// Only create user message if there's content (text or other non-file items)
+					if (contentItems.length > 0) {
+						return [
+							{
+								role: "user",
+								content: contentItems,
+							},
+						] as Array<CompletionRequest | ChatCompletionMessage>;
+					} else {
+						// If all content was files, return empty string content
+						return [
+							{
+								role: "user",
+								content: "",
+							},
+						] as Array<CompletionRequest | ChatCompletionMessage>;
+					}
+				}
+				case "assistant": {
+					const assistantText = promptMsg.content.find((msg) => msg.type === "text");
+					const assistantToolCalls = promptMsg.content.filter((msg) => msg.type === "tool-call");
+					return [
+						{
+							role: "assistant",
+							content: assistantText?.text ?? null,
+							tool_calls: assistantToolCalls.map((tool) => ({
+								id: tool.toolCallId,
+								type: "function",
+								function: {
+									name: tool.toolName,
+									arguments: JSON.stringify(tool.input),
+								},
+							})),
+						},
+					] as Array<CompletionRequest | ChatCompletionMessage>;
+				}
+				case "tool": {
+					const toolCalls = promptMsg.content.filter((part) => part.type === "tool-result");
+					return [
+						...toolCalls.map((tool) => ({
+							role: "tool" as const,
+							tool_call_id: tool.toolCallId,
+							content: parseToolResultOutput(tool.output),
+						})),
+					];
+				}
+			}
+		})
+		.flat();
+
+	return { messages: promptMessages, attachments };
+}
+
+/**
+ * Processes tool results from the raw prompt and logs them to Maxim.
+ * Calls toolCallError for error-type results (error-text, error-json) and toolCallResult for successes.
+ *
+ * @param prompt - The raw LanguageModelV4 prompt containing tool results
+ * @param logger - The MaximLogger instance for logging tool results/errors
+ */
+export function processToolResultsFromPromptV4(prompt: LanguageModelV4Prompt, logger: MaximLogger): void {
+	for (const promptMsg of prompt) {
+		if (promptMsg.role !== "tool") continue;
+
+		for (const part of promptMsg.content) {
+			if (part.type !== "tool-result") continue;
+
+			const toolCallId = (part as { toolCallId: string }).toolCallId;
+			const output = (part as { output: { type: string; value?: unknown } }).output;
+			const isError = output.type === "error-text" || output.type === "error-json";
+
+			if (isError) {
+				const errorInfo = extractErrorInfo(output.value) as ToolCallError;
+				logger.toolCallError(toolCallId, errorInfo);
+			} else {
+				const content = parseToolResultOutput(output as Parameters<typeof parseToolResultOutput>[0]);
+				logger.toolCallResult(toolCallId, content);
+			}
+		}
+	}
+}
+
+/**
+ * Converts a doGenerate result object into a ChatCompletionResult format.
+ *
+ * This function adapts the result of a language model generation v4 (including token usage, model info, and choices) into the standardized ChatCompletionResult structure expected by downstream consumers.
+ *
+ * @param result - The result object from a generation call, including usage, response, and content fields.
+ * @returns The formatted chat completion result, including id, model, choices, and token usage.
+ */
+export function convertDoGenerateResultToChatCompletionResultV4(result: LanguageModelV4GenerateResult): ChatCompletionResult {
+	return {
+		id: uuid(),
+		object: "chat_completion",
+		created: Math.floor(Date.now() / 1000),
+		model: result.response?.modelId ?? "unknown",
+		choices: result.content.map((content, index) => {
+			switch (content.type) {
+				case "text":
+					return {
+						index,
+						message: {
+							content: content.text,
+							role: "assistant",
+						},
+						finish_reason: result.finishReason.unified,
+						logprobs: null,
+					} as ChatCompletionChoice;
+				case "file":
+					return {
+						index,
+						message: {
+							// v4 file data is a tagged union ({ type: 'data' | 'url' })
+							content: renderFileContent(content.data),
+							role: "assistant",
+						},
+						finish_reason: result.finishReason.unified,
+						logprobs: null,
+					} as ChatCompletionChoice;
+				case "tool-call":
+					return {
+						index,
+						logprobs: null,
+						message: {
+							content: null,
+							role: "assistant",
+							tool_calls: [
+								{
+									id: content.toolCallId,
+									type: "function",
+									function: {
+										name: content.toolName,
+										arguments: content.input,
+									},
+								},
+							],
+						},
+						finish_reason: result.finishReason.unified,
+					} as ChatCompletionChoice;
+				case "tool-result":
+					return {
+						index,
+						logprobs: null,
+						message: {
+							content: typeof content.result === "string" ? content.result : JSON.stringify(content.result),
+							role: "assistant",
+						},
+						finish_reason: result.finishReason.unified,
+					} as ChatCompletionChoice;
+				case "source":
+					return {
+						index,
+						logprobs: null,
+						message: {
+							content: content.sourceType === "url" ? content.url : content.title,
+							role: "assistant",
+						},
+						finish_reason: result.finishReason.unified,
+					} as ChatCompletionChoice;
+				default:
+					return {
+						index,
+						logprobs: null,
+						message: {
+							content: JSON.stringify(content),
+							role: "assistant",
+						},
+						finish_reason: result.finishReason.unified,
+					} as ChatCompletionChoice;
+			}
+		}),
+		usage: {
+			prompt_tokens: result.usage.inputTokens.total ?? 0,
+			completion_tokens: result.usage.outputTokens.total ?? 0,
+			total_tokens: (result.usage.inputTokens.total ?? 0) + (result.usage.outputTokens.total ?? 0),
+		},
+	};
+}
+
+/**
+ * Processes a stream of language model output chunks and logs the result to Maxim tracing.
+ *
+ * This function aggregates streamed output parts, constructs a chat completion result, and finalizes the generation, span, and trace as appropriate. It also handles errors and ensures proper cleanup of tracing resources.
+ *
+ * @param chunks - The array of streamed output parts from the language model.
+ * @param span - The Maxim tracing span associated with this generation.
+ * @param trace - The Maxim tracing trace associated with this generation.
+ * @param generation - The Maxim generation object to log the result to.
+ * @param model - The model identifier used for this generation.
+ * @param maximMetadata - Optional Maxim metadata for advanced tracing.
+ */
+export function processStreamV4(
+	chunks: LanguageModelV4StreamPart[],
+	span: Span,
+	trace: Trace,
+	generation: Generation,
+	model: string,
+	maximMetadata: MaximVercelProviderMetadata | undefined,
+) {
+	try {
+		const result = processChunksV4(chunks);
+
+		generation.result({
+			id: uuid(),
+			object: "chat_completion",
+			created: Math.floor(Date.now() / 1000),
+			model: model,
+			choices: [
+				{
+					index: 0,
+					message: {
+						tool_calls: result.toolCalls.map((toolCall) => ({
+							id: toolCall.toolCallId,
+							// Chat-completion tool calls use "function"; the stream part's own
+							// discriminator is "tool-call". Normalize so streamed and
+							// non-streamed results log the same shape.
+							type: "function",
+							function: {
+								name: toolCall.toolName,
+								arguments: toolCall.input,
+							},
+						})),
+						content: result.text,
+						role: "assistant",
+					},
+					finish_reason: result.finishReason ?? "stop",
+					logprobs: null,
+				},
+			],
+			usage: {
+				prompt_tokens: result.usage?.promptTokens ?? 0,
+				completion_tokens: result.usage?.completionTokens ?? 0,
+				total_tokens: (result.usage?.promptTokens ?? 0) + (result.usage?.completionTokens ?? 0),
+			},
+		});
+		generation.end();
+	} catch (error) {
+		generation.error({
+			message: (error as Error).message,
+		});
+		console.error("[Maxim SDK] Logging failed:", error);
+	} finally {
+		span.end();
+		// Note: Trace ending is now handled by the wrapper to support tool-call sequences
+	}
+}
+
+/**
+ * Processes an array of streamed language model output chunks into a structured result.
+ *
+ * This function aggregates text, tool calls, token usage, and finish reason from the provided stream parts, returning a single object summarizing the output of the language model stream.
+ *
+ * @param chunks - The array of streamed output parts from the language model.
+ * @returns An object containing the aggregated text, tool calls, token usage, and finish reason.
+ */
+function processChunksV4(chunks: LanguageModelV4StreamPart[]) {
+	let text = "";
+	const toolCalls: Record<string, LanguageModelV4ToolCall> = {};
+	let usage:
+		| {
+				promptTokens: number;
+				completionTokens: number;
+		  }
+		| undefined = undefined;
+	let finishReason: string | undefined = undefined;
+
+	for (const chunk of chunks) {
+		switch (chunk.type) {
+			case "text-delta":
+				text += chunk.delta;
+				break;
+			case "tool-call":
+				toolCalls[chunk.toolCallId] = chunk;
+				break;
+			case "tool-result":
+				text += typeof chunk.result === "string" ? chunk.result : JSON.stringify(chunk.result);
+				break;
+			case "finish":
+				usage = {
+					promptTokens: chunk.usage.inputTokens.total ?? 0,
+					completionTokens: chunk.usage.outputTokens.total ?? 0,
+				};
+				finishReason = chunk.finishReason.unified;
+				break;
+		}
+	}
+
+	return { text, toolCalls: Object.values(toolCalls), usage, finishReason };
+}

--- a/src/lib/logger/vercel/v4/vercelLoggerV4.mock.test.ts
+++ b/src/lib/logger/vercel/v4/vercelLoggerV4.mock.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Self-contained tests for the AI SDK v4 (AI SDK 7) wrapper.
+ *
+ * The wrapper depends only on the `ai-sdk-provider-v4` interface types and a
+ * `MaximLogger` — NOT on the `ai` package — so these tests hand-roll a
+ * `LanguageModelV4` mock and drive `doGenerate` / `doStream` directly. That
+ * keeps them runnable without upgrading the repo's pinned `ai@6` to `ai@7`
+ * (the two cannot coexist) and without any API keys or external network.
+ *
+ * Maxim ingestion is faked with an in-process HTTP server so we can assert
+ * both behavior (routing, stream pass-through, result shaping) and log
+ * delivery.
+ *
+ * Run:
+ *   npx jest src/lib/logger/vercel/v4/vercelLoggerV4.mock.test.ts --verbose
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type {
+	LanguageModelV4,
+	LanguageModelV4CallOptions,
+	LanguageModelV4GenerateResult,
+	LanguageModelV4Prompt,
+	LanguageModelV4StreamPart,
+	LanguageModelV4Usage,
+} from "ai-sdk-provider-v4";
+import { Maxim } from "../../../../../index";
+import { wrapMaximAISDKModel } from "../../../../../vercel-ai-sdk";
+import type { MaximLogger } from "../../logger";
+import { MaximAISDKWrapperV4 } from "./wrapperV4";
+import { parsePromptMessagesV4 } from "./utils";
+
+jest.setTimeout(30_000);
+
+// ---------------------------------------------------------------------------
+// Mock Maxim API server (records POSTs to the log-ingestion endpoint)
+// ---------------------------------------------------------------------------
+
+interface MockMaximServer {
+	baseUrl: string;
+	pushes: string[];
+	close: () => Promise<void>;
+}
+
+function startMockMaximServer(): Promise<MockMaximServer> {
+	const pushes: string[] = [];
+	const server = http.createServer((req, res) => {
+		const bodyChunks: Buffer[] = [];
+		req.on("data", (chunk) => bodyChunks.push(chunk));
+		req.on("end", () => {
+			const body = Buffer.concat(bodyChunks).toString("utf8");
+			const isPushLogs = req.method === "POST" && (req.url ?? "").startsWith("/api/sdk/v3/log");
+			if (isPushLogs) {
+				pushes.push(body);
+				res.writeHead(200, { "Content-Type": "text/plain" });
+				res.end("ok");
+				return;
+			}
+			// Repo-existence check and everything else responds instantly
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ data: true }));
+		});
+	});
+
+	return new Promise((resolve) => {
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address() as AddressInfo;
+			resolve({
+				baseUrl: `http://127.0.0.1:${port}`,
+				pushes,
+				close: () =>
+					new Promise<void>((res2) => {
+						server.close(() => res2());
+						server.closeAllConnections?.();
+					}),
+			});
+		});
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Hand-rolled LanguageModelV4 mock
+// ---------------------------------------------------------------------------
+
+const MOCK_USAGE: LanguageModelV4Usage = {
+	inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+	outputTokens: { total: 20, text: 20, reasoning: 0 },
+};
+
+const STREAM_PARTS: LanguageModelV4StreamPart[] = [
+	{ type: "stream-start", warnings: [] },
+	{ type: "text-start", id: "txt-1" },
+	{ type: "text-delta", id: "txt-1", delta: "Hello " },
+	{ type: "text-delta", id: "txt-1", delta: "world" },
+	{ type: "text-end", id: "txt-1" },
+	{ type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: MOCK_USAGE },
+];
+
+function makeMockV4Model(overrides: Partial<LanguageModelV4> = {}): LanguageModelV4 {
+	return {
+		specificationVersion: "v4",
+		provider: "openai",
+		modelId: "gpt-mock-v4",
+		supportedUrls: {},
+		async doGenerate(): Promise<LanguageModelV4GenerateResult> {
+			return {
+				content: [{ type: "text", text: "Hello from the mock v4 model!" }],
+				finishReason: { unified: "stop", raw: "stop" },
+				usage: MOCK_USAGE,
+				warnings: [],
+			};
+		},
+		async doStream() {
+			return {
+				stream: new ReadableStream<LanguageModelV4StreamPart>({
+					start(controller) {
+						for (const part of STREAM_PARTS) controller.enqueue(part);
+						controller.close();
+					},
+				}),
+			};
+		},
+		...overrides,
+	} as LanguageModelV4;
+}
+
+function textPrompt(text: string): LanguageModelV4Prompt {
+	return [{ role: "user", content: [{ type: "text", text }] }];
+}
+
+async function drainStream(stream: ReadableStream<LanguageModelV4StreamPart>): Promise<LanguageModelV4StreamPart[]> {
+	const out: LanguageModelV4StreamPart[] = [];
+	const reader = stream.getReader();
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		out.push(value);
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AI SDK v4 (AI SDK 7) wrapper", () => {
+	let mockServer: MockMaximServer;
+	let maxim: Maxim;
+	let logger: MaximLogger;
+
+	beforeAll(async () => {
+		mockServer = await startMockMaximServer();
+		maxim = new Maxim({ baseUrl: mockServer.baseUrl, apiKey: "v4-test-key" });
+		const l = await maxim.logger({ id: "v4-log-repo", flushIntervalSeconds: 3600 });
+		if (!l) throw new Error("Failed to create logger");
+		logger = l;
+	});
+
+	afterAll(async () => {
+		await maxim.cleanup();
+		await mockServer.close();
+	});
+
+	beforeEach(() => {
+		mockServer.pushes.length = 0;
+	});
+
+	describe("routing", () => {
+		it("routes a specificationVersion 'v4' model to MaximAISDKWrapperV4", () => {
+			const wrapped = wrapMaximAISDKModel(makeMockV4Model(), logger);
+			expect(wrapped).toBeInstanceOf(MaximAISDKWrapperV4);
+			expect(wrapped.specificationVersion).toBe("v4");
+			expect(wrapped.modelId).toBe("gpt-mock-v4");
+			expect(wrapped.provider).toBe("openai");
+		});
+	});
+
+	describe("doGenerate", () => {
+		it("returns the underlying result unchanged and delivers a log", async () => {
+			const wrapped = wrapMaximAISDKModel(makeMockV4Model(), logger);
+			const options: LanguageModelV4CallOptions = { prompt: textPrompt("Say hello") };
+
+			const result = await wrapped.doGenerate(options);
+
+			expect(result.content).toEqual([{ type: "text", text: "Hello from the mock v4 model!" }]);
+			expect(result.finishReason.unified).toBe("stop");
+			await logger.flush();
+			expect(mockServer.pushes.length).toBeGreaterThan(0);
+		});
+
+		it("surfaces provider errors while still ending the trace", async () => {
+			const boom = makeMockV4Model({
+				doGenerate: async () => {
+					throw new Error("provider exploded");
+				},
+			});
+			const wrapped = wrapMaximAISDKModel(boom, logger);
+			await expect(wrapped.doGenerate({ prompt: textPrompt("hi") })).rejects.toThrow("provider exploded");
+		});
+	});
+
+	describe("doStream", () => {
+		it("passes chunks through unmodified, in order, and closes", async () => {
+			const wrapped = wrapMaximAISDKModel(makeMockV4Model(), logger);
+			const { stream } = await wrapped.doStream({ prompt: textPrompt("Say hello") });
+
+			const received = await drainStream(stream);
+
+			// The wrapper must forward the provider's parts verbatim.
+			expect(received).toEqual(STREAM_PARTS);
+			const text = received
+				.filter((p): p is Extract<LanguageModelV4StreamPart, { type: "text-delta" }> => p.type === "text-delta")
+				.map((p) => p.delta)
+				.join("");
+			expect(text).toBe("Hello world");
+
+			await logger.flush();
+			expect(mockServer.pushes.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe("parsePromptMessagesV4 (v4 file-data tagged union)", () => {
+		it("extracts a URL file attachment", () => {
+			const prompt: LanguageModelV4Prompt = [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "look at this" },
+						{ type: "file", mediaType: "image/png", data: { type: "url", url: new URL("https://example.com/cat.png") } },
+					],
+				},
+			];
+			const { messages, attachments } = parsePromptMessagesV4(prompt);
+			expect(attachments).toHaveLength(1);
+			expect(attachments[0]).toMatchObject({ type: "url", url: "https://example.com/cat.png", mimeType: "image/png" });
+			// Text content is preserved on the message
+			expect(messages[0]).toMatchObject({ role: "user" });
+		});
+
+		it("extracts inline bytes as a fileData attachment", () => {
+			const bytes = new Uint8Array([1, 2, 3, 4]);
+			const prompt: LanguageModelV4Prompt = [
+				{ role: "user", content: [{ type: "file", mediaType: "application/octet-stream", data: { type: "data", data: bytes } }] },
+			];
+			const { attachments } = parsePromptMessagesV4(prompt);
+			expect(attachments).toHaveLength(1);
+			expect(attachments[0]).toMatchObject({ type: "fileData", mimeType: "application/octet-stream" });
+			expect((attachments[0] as { data: Buffer }).data).toEqual(Buffer.from(bytes));
+		});
+
+		it("decodes a base64 data-URI file into bytes", () => {
+			const base64 = Buffer.from("hi").toString("base64");
+			const prompt: LanguageModelV4Prompt = [
+				{
+					role: "user",
+					content: [{ type: "file", mediaType: "text/plain", data: { type: "data", data: `data:text/plain;base64,${base64}` } }],
+				},
+			];
+			const { attachments } = parsePromptMessagesV4(prompt);
+			expect(attachments).toHaveLength(1);
+			expect((attachments[0] as { data: Buffer }).data.toString("utf8")).toBe("hi");
+		});
+
+		it("surfaces an inline text document as message text, not an attachment", () => {
+			const prompt: LanguageModelV4Prompt = [
+				{ role: "user", content: [{ type: "file", mediaType: "text/plain", data: { type: "text", text: "inline doc" } }] },
+			];
+			const { messages, attachments } = parsePromptMessagesV4(prompt);
+			expect(attachments).toHaveLength(0);
+			expect(JSON.stringify(messages[0])).toContain("inline doc");
+		});
+	});
+});

--- a/src/lib/logger/vercel/v4/vercelLoggerV4.test.ts
+++ b/src/lib/logger/vercel/v4/vercelLoggerV4.test.ts
@@ -1,0 +1,1506 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { openai } from "@ai-sdk/openai";
+import { generateText, Output, stepCountIs, streamText, tool } from "ai";
+import { config } from "dotenv";
+import fs from "node:fs";
+import path from "node:path";
+import { v4 as uuid } from "uuid";
+import { z } from "zod/v3";
+import { Maxim } from "../../../../../index";
+import { MaximVercelProviderMetadata, wrapMaximAISDKModel } from "../../../../../vercel-ai-sdk";
+
+config();
+
+let maxim: Maxim;
+
+// local config
+const openAIKey = process.env["OPENAI_API_KEY"];
+const anthropicApiKey = process.env["ANTHROPIC_API_KEY"];
+const apiKey = process.env["MAXIM_API_KEY"];
+const baseUrl = process.env["MAXIM_BASE_URL"];
+const repoId = process.env["MAXIM_LOG_REPO_ID"];
+
+describe("AI SDK V4 Specification Tests", () => {
+	beforeAll(async () => {
+		if (!apiKey || !repoId) {
+			throw new Error("MAXIM_API_KEY & LOG_REPO_ID environment variables are required");
+		}
+		maxim = new Maxim({
+			baseUrl: baseUrl,
+			apiKey: apiKey,
+			debug: true,
+		});
+	});
+
+	afterAll(async () => {
+		await maxim.cleanup();
+	});
+
+	describe("OpenAI V4 Model Tests", () => {
+		it("should trace OpenAI chat model with basic text using V4 specification", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			// Use a model that supports V4 specification
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.2"), logger);
+			const trace = logger.trace({
+				id: uuid(),
+				name: "Testing V4 specification for generateText",
+				tags: {
+					specification_version: "v4",
+					test_type: "basic_text",
+				},
+			});
+
+			const query = "What is the capital of France?";
+			trace.input(query);
+
+			try {
+				const response = await generateText({
+					model: model,
+					temperature: 0.3,
+					topP: 1,
+					system: "Be concise in your answers",
+					prompt: query,
+					maxOutputTokens: 100,
+					providerOptions: {
+						maxim: {
+							traceId: trace.id,
+							traceName: "V4 Basic Text Generation",
+							generationName: "France Capital Query",
+							generationTags: {
+								query_type: "geography",
+								specification: "v4",
+							},
+							traceTags: {
+								test_suite: "v4_specification",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+				console.log("OpenAI V4 response for basic generateText", response.text);
+				expect(response.text).toBeDefined();
+				expect(response.text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in V4 basic text generation:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 streaming text generation", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			try {
+				const result = streamText({
+					model: model,
+					maxOutputTokens: 200,
+					messages: [
+						{
+							role: "system",
+							content: "You are a helpful assistant that writes poetry.",
+						},
+						{
+							role: "user",
+							content: "Write a short poem about technology.",
+						},
+					],
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Stream Text Generation",
+							generationName: "Technology Poem Stream",
+							generationTags: {
+								content_type: "poetry",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				const text = await result.text;
+				console.log("OpenAI V4 streaming response", text);
+				expect(text).toBeDefined();
+				expect(text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in V4 stream text generation:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 object generation with schema", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			try {
+				const result = await generateText({
+					model: model,
+					output: Output.object({
+						schema: z.object({
+							city: z.string().describe("Name of a major city"),
+							country: z.string().describe("Country where the city is located"),
+							population: z.number().describe("Approximate population"),
+							landmarks: z.array(z.string()).describe("Famous landmarks in the city"),
+						}),
+					}),
+					prompt: "Generate information about Tokyo.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Object Generation",
+							generationName: "Tokyo City Info",
+							generationTags: {
+								output_type: "structured_object",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("OpenAI V4 object generation result", result.response.body);
+				expect(result.text).toBeDefined();
+				expect(result.content).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 object generation:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 streaming object generation", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+
+			try {
+				const result = streamText({
+					model: model,
+					output: Output.object({
+						schema: z.object({
+							title: z.string().describe("Book title"),
+							author: z.string().describe("Book author"),
+							genre: z.string().describe("Book genre"),
+							summary: z.string().describe("Brief book summary"),
+							chapters: z.array(z.string()).describe("Chapter titles"),
+						}),
+					}),
+					prompt: "Generate a fictional book about space exploration.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Stream Object Generation",
+							generationName: "Space Book Stream",
+							generationTags: {
+								output_type: "streaming_object",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				const object = await result.output;
+				console.log("OpenAI V4 streaming object result", object);
+				expect(object).toBeDefined();
+				expect(object.title).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 streaming object generation:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 tool calls with proper logging and execution", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			try {
+				const result = await generateText({
+					model: model,
+					tools: {
+						calculator: tool({
+							description: "Perform basic arithmetic operations",
+							inputSchema: z.object({
+								operation: z.enum(["add", "subtract", "multiply", "divide"]),
+								a: z.number().describe("First number"),
+								b: z.number().describe("Second number"),
+							}),
+							needsApproval: true,
+							execute: async ({ operation, a, b }) => {
+								console.log(`[CALCULATOR] Executing ${operation}(${a}, ${b})`);
+								switch (operation) {
+									case "add":
+										return { result: a + b };
+									case "subtract":
+										return { result: a - b };
+									case "multiply":
+										return { result: a * b };
+									case "divide":
+										return { result: b !== 0 ? a / b : "Cannot divide by zero" };
+									default:
+										return { result: "Invalid operation" };
+								}
+							},
+						}),
+					},
+					prompt: "Calculate 15 multiplied by 8, then add 25 to the result.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Tool Call Test - Single Execution",
+							generationName: "Calculator Operations",
+							generationTags: {
+								tool_usage: "calculator",
+								specification: "v4",
+								test_type: "single_tool_execution",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+					stopWhen: stepCountIs(5),
+				});
+
+				console.log("OpenAI V4 tool call result", result.text);
+				console.log("Tool calls executed:", result.toolCalls?.length || 0);
+				expect(result.text).toBeDefined();
+				expect(result.toolCalls).toBeDefined();
+				expect(result.toolCalls?.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in V4 tool call:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should capture tool execution error when using real model", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			const failingToolError = new Error("Tool execution failed: external service unavailable");
+
+			try {
+				await generateText({
+					model: model,
+					tools: {
+						calculator: tool({
+							description: "Perform basic arithmetic operations",
+							inputSchema: z.object({
+								operation: z.enum(["add", "subtract", "multiply", "divide"]),
+								a: z.number().describe("First number"),
+								b: z.number().describe("Second number"),
+							}),
+							execute: async (): Promise<{ result: number }> => {
+								throw failingToolError;
+							},
+						}),
+					},
+					prompt: "Calculate 15 multiplied by 8.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Tool Execution Error Test",
+							generationName: "Calculator Error",
+							generationTags: {
+								tool_usage: "calculator",
+								specification: "v4",
+								test_type: "tool_execution_error",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+					stopWhen: stepCountIs(5),
+				});
+
+				// If generateText resolves, the tool-error path was never exercised —
+				// fail explicitly so the assertions in catch aren't silently skipped.
+				fail("Expected tool execution to throw an error");
+			} catch (error) {
+				expect(error).toBe(failingToolError);
+				expect((error as Error).message).toBe("Tool execution failed: external service unavailable");
+			}
+		}, 20000);
+
+		it("should handle V4 multiple sequential tool calls in one trace", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			try {
+				const result = await generateText({
+					model: model,
+					tools: {
+						calculator: tool({
+							description: "Perform basic arithmetic operations",
+							inputSchema: z.object({
+								operation: z.enum(["add", "subtract", "multiply", "divide"]),
+								a: z.number().describe("First number"),
+								b: z.number().describe("Second number"),
+							}),
+							execute: async ({ operation, a, b }) => {
+								console.log(`[CALCULATOR] Executing ${operation}(${a}, ${b})`);
+								switch (operation) {
+									case "add":
+										return { result: a + b };
+									case "subtract":
+										return { result: a - b };
+									case "multiply":
+										return { result: a * b };
+									case "divide":
+										return { result: b !== 0 ? a / b : "Cannot divide by zero" };
+									default:
+										return { result: "Invalid operation" };
+								}
+							},
+						}),
+						getWeather: tool({
+							description: "Get current weather information for a city",
+							inputSchema: z.object({
+								city: z.string().describe("Name of the city"),
+								unit: z.enum(["celsius", "fahrenheit"]).describe("Temperature unit"),
+							}),
+							execute: async ({ city, unit }) => {
+								console.log(`[WEATHER] Getting weather for ${city} in ${unit}`);
+								return {
+									city,
+									temperature: unit === "celsius" ? 22 : 72,
+									unit,
+									condition: "sunny",
+									humidity: 65,
+								};
+							},
+						}),
+					},
+					prompt: "What's 10 + 5? Also, what's the weather in New York? Use Celsius.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Multiple Tool Calls Test",
+							generationName: "Multi-Tool Operations",
+							generationTags: {
+								tool_usage: "calculator,weather",
+								specification: "v4",
+								test_type: "multiple_tools",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+					stopWhen: stepCountIs(5),
+				});
+
+				console.log("OpenAI V4 multiple tool calls result", result.text);
+				console.log("Tool calls executed:", result.toolCalls?.length || 0);
+				expect(result.text).toBeDefined();
+				expect(result.toolCalls).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 multiple tool calls:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 streaming tool calls with execution", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			try {
+				const result = streamText({
+					model: model,
+					tools: {
+						calculator: tool({
+							description: "Perform basic arithmetic operations",
+							inputSchema: z.object({
+								operation: z.enum(["add", "subtract", "multiply", "divide"]),
+								a: z.number().describe("First number"),
+								b: z.number().describe("Second number"),
+							}),
+							execute: async ({ operation, a, b }) => {
+								console.log(`[CALCULATOR STREAM] Executing ${operation}(${a}, ${b})`);
+								switch (operation) {
+									case "add":
+										return { result: a + b };
+									case "subtract":
+										return { result: a - b };
+									case "multiply":
+										return { result: a * b };
+									case "divide":
+										return { result: b !== 0 ? a / b : "Cannot divide by zero" };
+									default:
+										return { result: "Invalid operation" };
+								}
+							},
+						}),
+					},
+					prompt: "Calculate 20 multiplied by 3, then subtract 10 from the result.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Streaming Tool Call Test",
+							generationName: "Stream Calculator Operations",
+							generationTags: {
+								tool_usage: "calculator",
+								specification: "v4",
+								test_type: "streaming_tool_execution",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+					stopWhen: stepCountIs(5),
+				});
+
+				const text = await result.text;
+				const toolCalls = await result.toolCalls;
+				console.log("OpenAI V4 streaming tool call result", text);
+				console.log("Tool calls executed:", toolCalls?.length || 0);
+				expect(text).toBeDefined();
+				expect(toolCalls).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 streaming tool call:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 complex multi-step tool execution", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			try {
+				const result = await generateText({
+					model: model,
+					tools: {
+						calculator: tool({
+							description: "Perform basic arithmetic operations",
+							inputSchema: z.object({
+								operation: z.enum(["add", "subtract", "multiply", "divide"]),
+								a: z.number().describe("First number"),
+								b: z.number().describe("Second number"),
+							}),
+							execute: async ({ operation, a, b }) => {
+								console.log(`[CALCULATOR] Executing ${operation}(${a}, ${b})`);
+								switch (operation) {
+									case "add":
+										return { result: a + b };
+									case "subtract":
+										return { result: a - b };
+									case "multiply":
+										return { result: a * b };
+									case "divide":
+										return { result: b !== 0 ? a / b : "Cannot divide by zero" };
+									default:
+										return { result: "Invalid operation" };
+								}
+							},
+						}),
+						getWeather: tool({
+							description: "Get current weather information for a city",
+							inputSchema: z.object({
+								city: z.string().describe("Name of the city"),
+								unit: z.enum(["celsius", "fahrenheit"]).describe("Temperature unit"),
+							}),
+							execute: async ({ city, unit }) => {
+								console.log(`[WEATHER] Getting weather for ${city} in ${unit}`);
+								return {
+									city,
+									temperature: unit === "celsius" ? 22 : 72,
+									unit,
+									condition: "sunny",
+									humidity: 65,
+								};
+							},
+						}),
+					},
+					prompt: "Calculate 15 multiplied by 8, then add 25 to the result. After that, tell me the weather in San Francisco in Celsius.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Complex Multi-Step Tool Execution",
+							generationName: "Complex Tool Operations",
+							generationTags: {
+								tool_usage: "calculator,weather",
+								specification: "v4",
+								test_type: "complex_multi_step",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+					stopWhen: stepCountIs(10),
+				});
+
+				console.log("OpenAI V4 complex tool execution result", result.text);
+				console.log("Tool calls executed:", result.toolCalls?.length || 0);
+				if (result.toolCalls && result.toolCalls.length > 0) {
+					result.toolCalls.forEach((tc, idx) => {
+						console.log(`  Tool Call ${idx + 1}:`, tc.toolName, JSON.stringify(tc));
+					});
+				}
+				expect(result.text).toBeDefined();
+				expect(result.toolCalls).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 complex tool execution:", error);
+				throw error;
+			}
+		}, 30000);
+
+		it("should handle V4 tool calls with session context", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+			const sessionId = uuid();
+
+			try {
+				const result = await generateText({
+					model: model,
+					tools: {
+						calculator: tool({
+							description: "Perform basic arithmetic operations",
+							inputSchema: z.object({
+								operation: z.enum(["add", "subtract", "multiply", "divide"]),
+								a: z.number().describe("First number"),
+								b: z.number().describe("Second number"),
+							}),
+							execute: async ({ operation, a, b }) => {
+								console.log(`[CALCULATOR SESSION] Executing ${operation}(${a}, ${b})`);
+								switch (operation) {
+									case "add":
+										return { result: a + b };
+									case "subtract":
+										return { result: a - b };
+									case "multiply":
+										return { result: a * b };
+									case "divide":
+										return { result: b !== 0 ? a / b : "Cannot divide by zero" };
+									default:
+										return { result: "Invalid operation" };
+								}
+							},
+						}),
+					},
+					prompt: "Calculate 100 divided by 4, then multiply the result by 3.",
+					providerOptions: {
+						maxim: {
+							sessionId: sessionId,
+							sessionName: "V4 Tool Call Session Test",
+							traceName: "Session Tool Execution",
+							generationName: "Session Calculator Operations",
+							sessionTags: {
+								test_type: "tool_call_session",
+								specification: "v4",
+							},
+							generationTags: {
+								tool_usage: "calculator",
+								specification: "v4",
+								test_type: "session_tool_execution",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+					stopWhen: stepCountIs(5),
+				});
+
+				console.log("OpenAI V4 session tool call result", result.text);
+				console.log("Tool calls executed:", result.toolCalls?.length || 0);
+				expect(result.text).toBeDefined();
+				expect(result.toolCalls).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 session tool call:", error);
+				throw error;
+			}
+		}, 20000);
+
+		const sessionId = uuid();
+		it("should handle V4 session and trace management", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			try {
+				// First call in session
+				const result1 = await generateText({
+					model: model,
+					prompt: "Hello, I'm starting a conversation about cooking.",
+					providerOptions: {
+						maxim: {
+							sessionId: sessionId,
+							sessionName: "V4 Cooking Conversation",
+							traceName: "Conversation Start",
+							sessionTags: {
+								topic: "cooking",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				// Second call in same session
+				const result2 = await generateText({
+					model: model,
+					prompt: "What's a good recipe for pasta?",
+					providerOptions: {
+						maxim: {
+							sessionId: sessionId,
+							sessionName: "V4 Cooking Conversation",
+							traceName: "Recipe Request",
+							sessionTags: {
+								topic: "cooking",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("V4 Session - First response:", result1.text);
+				console.log("V4 Session - Second response:", result2.text);
+
+				expect(result1.text).toBeDefined();
+				expect(result2.text).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 session management:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 multi-modal input with images", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-5.1"), logger);
+
+			try {
+				const result = await generateText({
+					model: model,
+					maxOutputTokens: 30000,
+					messages: [
+						{
+							role: "user",
+							content: [
+								{
+									type: "text",
+									text: "Describe what you see in this image in detail.",
+								},
+								{
+									type: "image",
+									image: new URL(
+										"https://us.robosen.com/cdn/shop/files/elite_op_robot_form_pc.webp?v=1719307595&width=2000",
+									),
+								},
+							],
+						},
+					],
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Multi-modal Analysis",
+							generationName: "Image Description",
+							generationTags: {
+								input_type: "multimodal",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("OpenAI V4 image analysis result", result.text);
+				expect(result.text).toBeDefined();
+				expect(result.text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in V4 multi-modal input:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 multi-modal input with local file path", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+
+			// Path to test image file - user should place a test image file here
+			const testImagePath = path.join(process.cwd(), "test-image.png");
+
+			// Skip test if file doesn't exist
+			if (!fs.existsSync(testImagePath)) {
+				console.warn(`Test image not found at ${testImagePath}. Skipping test. Please create a test image file at this path.`);
+				return;
+			}
+
+			try {
+				// Read the local file into a buffer
+				const fileBuffer = fs.readFileSync(testImagePath);
+
+				const result = await generateText({
+					model: model,
+					maxOutputTokens: 200,
+					messages: [
+						{
+							role: "user",
+							content: [
+								{
+									type: "text",
+									text: "Describe what you see in this image in detail.",
+								},
+								{
+									type: "file",
+									data: fileBuffer,
+									mediaType: "image/png",
+								},
+							],
+						},
+					],
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Multi-modal Local File Path Test",
+							generationName: "Local File Path Image Description",
+							generationTags: {
+								input_type: "multimodal_local_file_path",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("OpenAI V4 local file path image analysis result", result.text);
+				expect(result.text).toBeDefined();
+				expect(result.text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in V4 multi-modal local file path input:", error);
+				throw error;
+			}
+		}, 20000);
+	});
+
+	describe("Anthropic V4 Model Tests", () => {
+		it("should trace Anthropic model with V4 specification", async () => {
+			if (!repoId || !anthropicApiKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and ANTHROPIC_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(anthropic("claude-opus-4-5-20251101"), logger);
+
+			try {
+				const response = await generateText({
+					model: model,
+					temperature: 0.2,
+					maxOutputTokens: 150,
+					system: "You are a helpful assistant that provides concise answers.",
+					prompt: "Explain quantum computing in simple terms.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Anthropic Text Generation",
+							generationName: "Quantum Computing Explanation",
+							generationTags: {
+								provider: "anthropic",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("Anthropic V4 response", response.text);
+				expect(response.text).toBeDefined();
+				expect(response.text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in Anthropic V4 generation:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle Anthropic V4 streaming", async () => {
+			if (!repoId || !anthropicApiKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and ANTHROPIC_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(anthropic("claude-opus-4-5-20251101"), logger);
+
+			try {
+				const result = streamText({
+					model: model,
+					temperature: 0.3,
+					maxOutputTokens: 200,
+					prompt: "Write a brief story about a robot learning to paint.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Anthropic Stream",
+							generationName: "Robot Painting Story",
+							generationTags: {
+								provider: "anthropic",
+								specification: "v4",
+								content_type: "creative_writing",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				const text = await result.text;
+				console.log("Anthropic V4 streaming result", text);
+				expect(text).toBeDefined();
+				expect(text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in Anthropic V4 streaming:", error);
+				throw error;
+			}
+		}, 20000);
+	});
+
+	describe("V4 Error Handling Tests", () => {
+		it("should properly handle and log errors in V4 specification", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+
+			try {
+				// Intentionally cause an error with invalid parameters
+				await generateText({
+					model: model,
+					maxOutputTokens: -1, // Invalid token count
+					prompt: "This should cause an error.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Error Handling Test",
+							generationName: "Invalid Parameters",
+							generationTags: {
+								test_type: "error_handling",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				// If we reach here, the test should fail
+				fail("Expected an error to be thrown");
+			} catch (error) {
+				console.log("Expected error caught in V4 error handling test:", error);
+				expect(error).toBeDefined();
+			}
+		}, 20000);
+
+		it("should capture a standard Error thrown by the model in doGenerate", async () => {
+			if (!repoId) throw new Error("MAXIM_LOG_REPO_ID environment variable is required");
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) throw new Error("Logger is not available");
+
+			// Mock model that throws a standard Error with a code property
+			const fakeModel = {
+				specificationVersion: "v4" as const,
+				provider: "openai",
+				modelId: "fake-model",
+				supportedUrls: {},
+				doGenerate: async () => {
+					const err = new TypeError("context length exceeded");
+					(err as unknown as Record<string, unknown>)["code"] = "context_length_exceeded";
+					throw err;
+				},
+				doStream: async () => {
+					throw new Error("not used");
+				},
+			};
+
+			const model = wrapMaximAISDKModel(fakeModel as never, logger);
+
+			try {
+				await generateText({
+					model,
+					prompt: "trigger a standard Error",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Standard Error Test",
+							generationName: "Standard Error Generation",
+						} as MaximVercelProviderMetadata,
+					},
+				});
+				fail("Expected an error to be thrown");
+			} catch (error) {
+				expect(error).toBeInstanceOf(TypeError);
+				expect((error as TypeError).message).toBe("context length exceeded");
+			}
+		}, 10000);
+
+		it("should capture an API-style plain object error thrown by the model in doGenerate", async () => {
+			if (!repoId) throw new Error("MAXIM_LOG_REPO_ID environment variable is required");
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) throw new Error("Logger is not available");
+
+			// Mock model that throws a plain object (as some API clients do)
+			const fakeModel = {
+				specificationVersion: "v4" as const,
+				provider: "openai",
+				modelId: "fake-model",
+				supportedUrls: {},
+				doGenerate: async () => {
+					 
+					throw { message: "rate limit exceeded", code: "429", type: "rate_limit_error" };
+				},
+				doStream: async () => {
+					throw new Error("not used");
+				},
+			};
+
+			const model = wrapMaximAISDKModel(fakeModel as never, logger);
+
+			try {
+				await generateText({
+					model,
+					prompt: "trigger a plain object error",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Plain Object Error Test",
+							generationName: "Plain Object Error Generation",
+						} as MaximVercelProviderMetadata,
+					},
+				});
+				fail("Expected an error to be thrown");
+			} catch (error) {
+				// The error is re-thrown as-is so the caller can inspect it
+				expect(error).toEqual({ message: "rate limit exceeded", code: "429", type: "rate_limit_error" });
+			}
+		}, 10000);
+
+		it("should capture a standard Error thrown by the model in doStream", async () => {
+			if (!repoId) throw new Error("MAXIM_LOG_REPO_ID environment variable is required");
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) throw new Error("Logger is not available");
+
+			// Mock model whose stream reader throws mid-stream
+			const fakeModel = {
+				specificationVersion: "v4" as const,
+				provider: "openai",
+				modelId: "fake-model",
+				supportedUrls: {},
+				doGenerate: async () => {
+					throw new Error("not used");
+				},
+				doStream: async () => ({
+					stream: new ReadableStream({
+						start(controller) {
+							controller.error(new RangeError("stream interrupted"));
+						},
+					}),
+					rawCall: { rawPrompt: null, rawSettings: {} },
+					rawResponse: { headers: {} },
+					request: { body: "" },
+					warnings: [],
+				}),
+			};
+
+			const model = wrapMaximAISDKModel(fakeModel as never, logger);
+
+			try {
+				const result = streamText({
+					model,
+					prompt: "trigger a stream error",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Stream Error Test",
+							generationName: "Stream Error Generation",
+						} as MaximVercelProviderMetadata,
+					},
+				});
+				await result.text;
+				fail("Expected an error to be thrown");
+			} catch (error) {
+				expect(error).toBeDefined();
+			}
+		}, 30000);
+
+		it("should capture a plain object error thrown during doStream setup", async () => {
+			if (!repoId) throw new Error("MAXIM_LOG_REPO_ID environment variable is required");
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) throw new Error("Logger is not available");
+
+			// Mock model that throws before returning a stream (doStream itself rejects)
+			const fakeModel = {
+				specificationVersion: "v4" as const,
+				provider: "openai",
+				modelId: "fake-model",
+				supportedUrls: {},
+				doGenerate: async () => {
+					throw new Error("not used");
+				},
+				doStream: async () => {
+					 
+					throw { message: "upstream unavailable", code: "503", type: "service_unavailable" };
+				},
+			};
+
+			const model = wrapMaximAISDKModel(fakeModel as never, logger);
+
+			try {
+				const result = streamText({
+					model,
+					prompt: "trigger a doStream setup error",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 doStream Setup Error Test",
+							generationName: "doStream Setup Error",
+						} as MaximVercelProviderMetadata,
+					},
+				});
+				await result.text;
+				fail("Expected an error to be thrown");
+			} catch (error) {
+				expect(error).toBeDefined();
+			}
+		}, 10000);
+	});
+
+	describe("V4 Performance and Edge Cases", () => {
+		it("should handle concurrent V4 model calls", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+
+			try {
+				const promises = Array.from({ length: 3 }, (_, i) =>
+					generateText({
+						model: model,
+						maxOutputTokens: 50,
+						prompt: `Generate a random fact about space. Call ${i + 1}`,
+						providerOptions: {
+							maxim: {
+								traceName: `V4 Concurrent Call ${i + 1}`,
+								generationName: `Space Fact ${i + 1}`,
+								generationTags: {
+									call_number: `${i + 1}`,
+									specification: "v4",
+									test_type: "concurrent",
+								},
+							} as MaximVercelProviderMetadata,
+						},
+					}),
+				);
+
+				const results = await Promise.all(promises);
+
+				console.log(
+					"V4 Concurrent call results:",
+					results.map((r) => r.text),
+				);
+				expect(results).toHaveLength(3);
+				results.forEach((result) => {
+					expect(result.text).toBeDefined();
+					expect(result.text.length).toBeGreaterThan(0);
+				});
+			} catch (error) {
+				console.error("Error in V4 concurrent calls:", error);
+				throw error;
+			}
+		}, 30000);
+
+		it("should handle V4 model with custom span and trace IDs", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+			const customTraceId = uuid();
+			const customSpanId = uuid();
+
+			try {
+				const result = await generateText({
+					model: model,
+					maxOutputTokens: 100,
+					prompt: "What is the meaning of life?",
+					providerOptions: {
+						maxim: {
+							traceId: customTraceId,
+							spanId: customSpanId,
+							traceName: "V4 Custom IDs Test",
+							spanName: "Philosophy Question",
+							generationName: "Life Meaning Query",
+							generationTags: {
+								custom_ids: "true",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("V4 Custom IDs result", result.text);
+				expect(result.text).toBeDefined();
+				expect(result.text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in V4 custom IDs test:", error);
+				throw error;
+			}
+		}, 20000);
+	});
+
+	describe("V4-Specific Features", () => {
+		it("should handle V4 file content processing", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+
+			try {
+				// Simulate V4 file handling with text content
+				const result = await generateText({
+					model: model,
+					maxOutputTokens: 200,
+					messages: [
+						{
+							role: "user",
+							content: [
+								{
+									type: "text",
+									text: "Analyze this file content and provide a summary:",
+								},
+								// Note: In real V4 implementation, this would be a file type
+								{
+									type: "text",
+									text: "File content: This is a sample document about renewable energy sources including solar, wind, and hydroelectric power.",
+								},
+							],
+						},
+					],
+					providerOptions: {
+						maxim: {
+							traceName: "V4 File Content Analysis",
+							generationName: "Document Summary",
+							generationTags: {
+								input_type: "file_content",
+								specification: "v4",
+								content_type: "document",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("V4 file content analysis result", result.text);
+				expect(result.text).toBeDefined();
+				expect(result.text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in V4 file content processing:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 advanced tool result processing", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+
+			try {
+				const result = await generateText({
+					model: model,
+					tools: {
+						dataAnalyzer: tool({
+							description: "Analyze data and return structured results",
+							inputSchema: z.object({
+								data: z.array(z.number()).describe("Array of numbers to analyze"),
+								analysisType: z.enum(["mean", "median", "mode", "range"]).describe("Type of analysis"),
+							}),
+							execute: async ({ data, analysisType }) => {
+								switch (analysisType) {
+									case "mean":
+										return {
+											result: data.reduce((a, b) => a + b, 0) / data.length,
+											type: "mean",
+											dataPoints: data.length,
+										};
+									case "median": {
+										const sorted = [...data].sort((a, b) => a - b);
+										const mid = Math.floor(sorted.length / 2);
+										return {
+											result: sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid],
+											type: "median",
+											dataPoints: data.length,
+										};
+									}
+									case "range":
+										return {
+											result: Math.max(...data) - Math.min(...data),
+											type: "range",
+											min: Math.min(...data),
+											max: Math.max(...data),
+											dataPoints: data.length,
+										};
+									default:
+										return { result: "Analysis type not supported", type: "error" };
+								}
+							},
+						}),
+					},
+					stopWhen: stepCountIs(10),
+					prompt: "Analyze this dataset: [10, 15, 20, 25, 30, 35, 40] and calculate the mean and range.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Advanced Tool Processing",
+							generationName: "Data Analysis Tool",
+							generationTags: {
+								tool_type: "data_analyzer",
+								specification: "v4",
+								analysis_complexity: "advanced",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("V4 advanced tool result", result.text);
+				expect(result.text).toBeDefined();
+				expect(result.text.length).toBeGreaterThan(0);
+			} catch (error) {
+				console.error("Error in V4 advanced tool processing:", error);
+				throw error;
+			}
+		}, 20000);
+
+		it("should handle V4 complex multi-turn conversation", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+			const conversationTraceId = uuid();
+
+			try {
+				// First turn
+				const turn1 = await generateText({
+					model: model,
+					maxOutputTokens: 100,
+					messages: [
+						{
+							role: "user",
+							content: "I'm planning a trip to Japan. What should I know about the culture?",
+						},
+					],
+					providerOptions: {
+						maxim: {
+							traceId: conversationTraceId,
+							traceName: "V4 Multi-turn Japan Conversation",
+							generationName: "Culture Question",
+							generationTags: {
+								turn: "1",
+								topic: "japan_culture",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				// Second turn - building on the conversation
+				const turn2 = await generateText({
+					model: model,
+					maxOutputTokens: 100,
+					messages: [
+						{
+							role: "user",
+							content: "I'm planning a trip to Japan. What should I know about the culture?",
+						},
+						{
+							role: "assistant",
+							content: turn1.text,
+						},
+						{
+							role: "user",
+							content: "That's helpful! What about food etiquette specifically?",
+						},
+					],
+					providerOptions: {
+						maxim: {
+							traceId: conversationTraceId,
+							traceName: "V4 Multi-turn Japan Conversation",
+							generationName: "Food Etiquette Question",
+							generationTags: {
+								turn: "2",
+								topic: "food_etiquette",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				// Third turn - more specific follow-up
+				const turn3 = await generateText({
+					model: model,
+					maxOutputTokens: 100,
+					messages: [
+						{
+							role: "user",
+							content: "I'm planning a trip to Japan. What should I know about the culture?",
+						},
+						{
+							role: "assistant",
+							content: turn1.text,
+						},
+						{
+							role: "user",
+							content: "That's helpful! What about food etiquette specifically?",
+						},
+						{
+							role: "assistant",
+							content: turn2.text,
+						},
+						{
+							role: "user",
+							content: "Should I learn some basic Japanese phrases before going?",
+						},
+					],
+					providerOptions: {
+						maxim: {
+							traceId: conversationTraceId,
+							traceName: "V4 Multi-turn Japan Conversation",
+							generationName: "Language Question",
+							generationTags: {
+								turn: "3",
+								topic: "language_learning",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("V4 Multi-turn conversation results:");
+				console.log("Turn 1:", turn1.text);
+				console.log("Turn 2:", turn2.text);
+				console.log("Turn 3:", turn3.text);
+
+				expect(turn1.text).toBeDefined();
+				expect(turn2.text).toBeDefined();
+				expect(turn3.text).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 multi-turn conversation:", error);
+				throw error;
+			}
+		}, 30000);
+
+		it("should handle V4 specification version validation", async () => {
+			if (!repoId || !openAIKey) {
+				throw new Error("MAXIM_LOG_REPO_ID and OPENAI_API_KEY environment variables are required");
+			}
+			const logger = await maxim.logger({ id: repoId });
+			if (!logger) {
+				throw new Error("Logger is not available");
+			}
+
+			const model = wrapMaximAISDKModel(openai.chat("gpt-4o-mini"), logger);
+
+			// Verify that the wrapped model maintains V4 specification
+			expect(model.specificationVersion).toBe("v4");
+			expect(model.modelId).toBeDefined();
+			expect(model.provider).toBeDefined();
+
+			try {
+				const result = await generateText({
+					model: model,
+					maxOutputTokens: 50,
+					prompt: "Hello, this is a V4 specification test.",
+					providerOptions: {
+						maxim: {
+							traceName: "V4 Specification Validation",
+							generationName: "Spec Version Test",
+							generationTags: {
+								test_type: "specification_validation",
+								specification: "v4",
+							},
+						} as MaximVercelProviderMetadata,
+					},
+				});
+
+				console.log("V4 specification validation result", result.text);
+				expect(result.text).toBeDefined();
+			} catch (error) {
+				console.error("Error in V4 specification validation:", error);
+				throw error;
+			}
+		}, 20000);
+	});
+});

--- a/src/lib/logger/vercel/v4/wrapperV4.ts
+++ b/src/lib/logger/vercel/v4/wrapperV4.ts
@@ -1,0 +1,499 @@
+import type { LanguageModelV4, LanguageModelV4CallOptions, LanguageModelV4StreamPart } from "ai-sdk-provider-v4";
+import { MaximLogger } from "../../logger";
+import {
+	determineProvider,
+	extractErrorInfo,
+	extractMaximMetadataFromOptions,
+	extractModelParameters,
+	flushAndCloseStream,
+	scheduleLoggerFlush,
+} from "./../utils";
+import { Generation, Session, Trace } from "../../components";
+import { v4 as uuid } from "uuid";
+import { ChatCompletionMessage, CompletionRequest } from "src/lib/models/prompt";
+import { convertDoGenerateResultToChatCompletionResultV4, parsePromptMessagesV4, processStreamV4, processToolResultsFromPromptV4 } from "./utils";
+import { LanguageFirstTokenModel } from "../types";
+
+export class MaximAISDKWrapperV4 implements LanguageModelV4 {
+	// Internal state to track trace across multiple doGenerate calls in a tool-call sequence
+	private currentTraceId: string | null = null;
+	private currentTrace: Trace | null = null;
+	private currentSession: Session | null = null;
+	private isInToolCallSequence: boolean = false;
+	// Track attachments that have been added to prevent duplicates across multiple doGenerate calls
+	// We use a hash of the file data to identify duplicates, since attachment IDs are regenerated each time
+	private addedAttachmentHashes: Set<string> = new Set();
+
+	/**
+	 * @constructor
+	 * Creates a new MaximAISDKWrapperV4 instance.
+	 *
+	 * @param model - The Vercel AI SDK v4 (AI SDK 7) language model instance to wrap.
+	 * @param logger - The MaximLogger instance to use for tracing and logging.
+	 */
+	constructor(
+		private model: LanguageModelV4,
+		private logger: MaximLogger,
+	) {}
+
+	/**
+	 * Sets up Maxim logging and tracing for a model call.
+	 *
+	 * Extracts Maxim metadata, parses prompt messages, and initializes session, trace, and span objects.
+	 * Also logs user input to the trace if appropriate.
+	 *
+	 * @private
+	 * @param options - The call options for the model invocation.
+	 * @param promptMessages - The parsed prompt messages (used to detect tool calls).
+	 * @returns An object containing maximMetadata, trace, session, span, and promptMessages.
+	 */
+	private setupLogging(options: LanguageModelV4CallOptions, promptMessages: Array<CompletionRequest | ChatCompletionMessage>) {
+		// Extracting the maxim object from `providerOptions`
+		const maximMetadata = extractMaximMetadataFromOptions(options.providerOptions);
+
+		// Check if this is a continuation of a tool-call sequence (has tool results in prompt)
+		const hasToolResults = promptMessages.some((msg) => msg.role === "tool");
+
+		// Determine if we should reuse the existing trace or create a new one
+		const shouldReuseTrace =
+			!maximMetadata?.traceId && // User hasn't explicitly provided a traceId
+			this.isInToolCallSequence && // We're in a tool-call sequence
+			hasToolResults && // This call has tool results (continuation)
+			this.currentTraceId !== null; // We have an existing trace
+
+		let session: Session | undefined = undefined;
+		let trace: Trace;
+
+		// If sessionId is passed, then create a session on Maxim. If not passed, do not create a session
+		if (maximMetadata?.sessionId) {
+			// Reuse existing session if it's the same sessionId, otherwise create new
+			if (this.currentSession?.id === maximMetadata.sessionId) {
+				session = this.currentSession;
+			} else {
+				session = this.logger.session({
+					id: maximMetadata.sessionId,
+					name: maximMetadata.sessionName ?? "default-session",
+					tags: maximMetadata.sessionTags,
+				});
+				this.currentSession = session;
+			}
+		}
+
+		// Determine trace ID: use user-provided, reuse existing, or create new
+		const traceId = maximMetadata?.traceId ?? (shouldReuseTrace ? this.currentTraceId! : uuid());
+		const traceName = maximMetadata?.traceName ?? "default-trace";
+
+		// Reuse existing trace if we're continuing a tool-call sequence
+		if (shouldReuseTrace && this.currentTrace) {
+			trace = this.currentTrace;
+		} else {
+			// Create new trace
+			trace = session
+				? session.trace({
+						id: traceId,
+						name: traceName,
+						tags: maximMetadata?.traceTags,
+					})
+				: this.logger.trace({
+						id: traceId,
+						name: traceName,
+						tags: maximMetadata?.traceTags,
+					});
+
+			// Store trace state for reuse
+			this.currentTraceId = traceId;
+			this.currentTrace = trace;
+		}
+
+		// If this is the start of a new sequence (no tool results), reset the tool-call sequence flag
+		if (!hasToolResults && !maximMetadata?.traceId) {
+			this.isInToolCallSequence = false;
+		}
+
+		const span = trace.span({
+			id: maximMetadata?.spanId ?? uuid(),
+			name: maximMetadata?.spanName ?? "default-span",
+			tags: maximMetadata?.spanTags,
+		});
+
+		const userMessage = promptMessages.findLast((msg) => msg.role === "user");
+		if (userMessage && userMessage.content) {
+			const userInput = userMessage.content;
+			if (typeof userInput === "string") {
+				trace.input(userInput);
+			} else {
+				const userMessageContent = userInput[0];
+				switch (userMessageContent.type) {
+					case "text":
+						trace.input(userMessageContent.text);
+						break;
+					case "image_url":
+						trace.input(userMessageContent.image_url.url);
+						trace.addAttachment({
+							id: uuid(),
+							type: "url",
+							url: userMessageContent.image_url.url,
+						});
+						break;
+					default:
+						break;
+				}
+			}
+		}
+
+		return { maximMetadata, trace, session, span, promptMessages };
+	}
+
+	/**
+	 * Executes a text or object generation call with Maxim tracing and logging.
+	 *
+	 * This method is called internally by generateText and generateObject, and logs the generation
+	 * result, errors, and relevant metadata to Maxim.
+	 *
+	 * @param options - The call options for the model invocation.
+	 * @returns The result of the underlying model's doGenerate call.
+	 */
+	async doGenerate(options: LanguageModelV4CallOptions) {
+		// Parse prompt messages first to detect tool calls and extract attachments
+		const { messages: promptMessages, attachments: fileAttachments } = parsePromptMessagesV4(options.prompt);
+		const { maximMetadata, trace, span } = this.setupLogging(options, promptMessages);
+		let generation: Generation | undefined = undefined;
+		let response: Awaited<ReturnType<LanguageModelV4["doGenerate"]>> | undefined = undefined;
+		let hasToolCallsInResponse = false;
+
+		try {
+			generation = span.generation({
+				id: uuid(),
+				name: maximMetadata?.generationName ?? "default-generation",
+				provider: determineProvider(this.model.provider),
+				model: this.modelId,
+				messages: promptMessages,
+				modelParameters: extractModelParameters(options),
+				tags: maximMetadata?.generationTags,
+			});
+
+			// Add file attachments to both generation and trace, avoiding duplicates
+			// We hash the file data to identify duplicates across multiple doGenerate calls
+			for (const attachment of fileAttachments) {
+				let identifier: string;
+
+				if (attachment.type === "fileData") {
+					// Create a simple hash of the file data to detect duplicates
+					identifier = this.hashBuffer(attachment.data);
+				} else {
+					// For URL and file path attachments, use the URL/path as the identifier
+					identifier = attachment.type === "url" ? attachment.url : attachment.path;
+				}
+
+				if (!this.addedAttachmentHashes.has(identifier)) {
+					generation.addAttachment({
+						...attachment,
+						id: uuid(),
+					});
+					trace.addAttachment({
+						...attachment,
+						id: uuid(),
+					});
+					this.addedAttachmentHashes.add(identifier);
+				}
+			}
+
+			processToolResultsFromPromptV4(options.prompt, this.logger);
+
+			// Calling the original doGenerate function
+			response = await this.model.doGenerate(options);
+
+			// Check if response has tool calls - if so, we're in a tool-call sequence
+			hasToolCallsInResponse = response.content?.some((content) => content.type === "tool-call") ?? false;
+
+			if (hasToolCallsInResponse) {
+				// Mark that we're in a tool-call sequence
+				this.isInToolCallSequence = true;
+			}
+
+			// Create ToolCall entities for any tool calls in the response
+			if (response.content) {
+				for (const content of response.content) {
+					if (content.type === "tool-call") {
+						const toolCallId = content.toolCallId;
+						const toolName = content.toolName;
+						const toolInput = typeof content.input === "string" ? content.input : JSON.stringify(content.input);
+
+						span.toolCall({
+							id: toolCallId,
+							name: toolName,
+							description: toolName,
+							args: toolInput,
+						});
+					}
+				}
+			}
+
+			const res = convertDoGenerateResultToChatCompletionResultV4(response);
+			generation.result(res);
+
+			return response;
+		} catch (error) {
+			if (generation) {
+				generation.error(extractErrorInfo(error));
+			}
+
+			// Log error details
+			console.error("[MaximSDK] doGenerate failed:", error);
+
+			throw error;
+		} finally {
+			span.end();
+
+			if (!hasToolCallsInResponse) {
+				this.addedAttachmentHashes.clear();
+			}
+			this.currentTraceId = null;
+			this.currentTrace = null;
+			this.isInToolCallSequence = false;
+			trace.end();
+			// Flush without blocking the caller where the environment allows it
+			await scheduleLoggerFlush(this.logger);
+		}
+	}
+
+	/**
+	 * Executes a streaming generation call with Maxim tracing and logging.
+	 *
+	 * This method is called internally by streamText and streamObject, and logs the streaming
+	 * result, errors, and relevant metadata to Maxim.
+	 *
+	 * @param options - The call options for the model invocation.
+	 * @returns The result of the underlying model's doStream call, with a wrapped stream.
+	 */
+	async doStream(options: LanguageModelV4CallOptions) {
+		// Parse prompt messages first to detect tool calls and extract attachments
+		const { messages: promptMessages, attachments: fileAttachments } = parsePromptMessagesV4(options.prompt);
+		const { maximMetadata, trace, span } = this.setupLogging(options, promptMessages);
+		let generation: Generation | undefined = undefined;
+		let hasToolCallsInResponse = false;
+		// Capture 'this' reference for use inside the stream
+		const wrapperInstance = this;
+
+		try {
+			// Process tool results from prompt before streaming (same as doGenerate)
+			// so toolCallResult/toolCallError are logged even if doStream or reader.read throws.
+			// Must be inside try so any throw flows into catch/flush path.
+			processToolResultsFromPromptV4(options.prompt, this.logger);
+
+			// Calling the original doStream method
+			const startTime = performance.now();
+			const response = await this.model.doStream(options);
+			const modelProvider = determineProvider(this.model.provider);
+			const modelId = this.modelId;
+
+			generation = span.generation({
+				id: uuid(),
+				name: maximMetadata?.generationName ?? "default-generation",
+				provider: modelProvider,
+				model: modelId,
+				modelParameters: extractModelParameters(options),
+				messages: promptMessages,
+			});
+
+			// Add file attachments to both generation and trace, avoiding duplicates
+			// We hash the file data to identify duplicates across multiple doGenerate calls
+			for (const attachment of fileAttachments) {
+				let identifier: string;
+
+				if (attachment.type === "fileData") {
+					// Create a simple hash of the file data to detect duplicates
+					identifier = wrapperInstance.hashBuffer(attachment.data);
+				} else {
+					// For URL and file path attachments, use the URL/path as the identifier
+					identifier = attachment.type === "url" ? attachment.url : attachment.path;
+				}
+
+				if (!wrapperInstance.addedAttachmentHashes.has(identifier)) {
+					generation.addAttachment({
+						...attachment,
+						id: uuid(),
+					});
+					trace.addAttachment({
+						...attachment,
+						id: uuid(),
+					});
+					wrapperInstance.addedAttachmentHashes.add(identifier);
+				}
+			}
+
+			// going through the original stream to collect chunks and pass them without modifications to the stream
+			const chunks: LanguageModelV4StreamPart[] = [];
+			const firstToken: LanguageFirstTokenModel = {
+				received: false,
+				time: null,
+			};
+
+			const stream = new ReadableStream<LanguageModelV4StreamPart>({
+				async start(controller) {
+					try {
+						const reader = response.stream.getReader();
+
+						while (true) {
+							const { done, value } = await reader.read();
+
+							if (done) {
+								// Stream is done, now process before closing
+								try {
+									// Check if we have tool calls in the stream
+									hasToolCallsInResponse = chunks.some((chunk) => chunk.type === "tool-call");
+
+									if (hasToolCallsInResponse) {
+										// Mark that we're in a tool-call sequence
+										wrapperInstance.isInToolCallSequence = true;
+									}
+
+									if (firstToken.received && firstToken.time) {
+										trace.addMetric("time_to_first_token (in ms)", firstToken.time - startTime);
+										firstToken.received = false;
+										firstToken.time = null;
+									}
+									const endTime = performance.now();
+									const textChunks = chunks.filter((chunk) => chunk.type === "text-delta" || chunk.type === "tool-input-delta");
+									trace.addMetric("tokens_per_second", textChunks.length / ((endTime - startTime) / 1000));
+									if (generation) processStreamV4(chunks, span, trace, generation, modelId, maximMetadata);
+
+									// Handle trace ending after stream processing
+									// End trace if:
+									// 1. User explicitly provided traceId (they manage it) - but don't reset state
+									// 2. OR response has no tool calls (sequence is complete or single call)
+									if (!hasToolCallsInResponse) {
+										// Reset attachment tracking when sequence is complete
+										wrapperInstance.addedAttachmentHashes.clear();
+									}
+									wrapperInstance.currentTraceId = null;
+									wrapperInstance.currentTrace = null;
+									wrapperInstance.isInToolCallSequence = false;
+									trace.end();
+								} catch (error) {
+									console.error("[MaximSDK] Processing failed:", error);
+									if (generation) {
+										generation.error(extractErrorInfo(error));
+										generation.end();
+									}
+								}
+
+								// Close the stream and flush logs with environment-appropriate
+								// ordering — consumers (e.g. streamText) are only unblocked once
+								// the stream closes, so the flush must not delay close() unless
+								// the environment leaves no alternative (bare AWS Lambda).
+								await flushAndCloseStream(wrapperInstance.logger, () => controller.close());
+								break;
+							}
+
+							if (!firstToken.received && (value.type === "text-delta" || value.type === "tool-input-delta")) {
+								firstToken.received = true;
+								firstToken.time = performance.now();
+							}
+
+							// Collect chunk and pass it through
+							chunks.push(value);
+							controller.enqueue(value);
+						}
+					} catch (error) {
+						controller.error(error);
+						if (generation) {
+							generation.error(extractErrorInfo(error));
+							generation.end();
+						}
+						// Flush logs on stream error (non-blocking where possible)
+						await scheduleLoggerFlush(wrapperInstance.logger);
+					}
+				},
+			});
+
+			// Return response with the logging stream - user gets real-time data without additional delay
+			return {
+				...response,
+				stream: stream,
+			};
+		} catch (error) {
+			if (generation) {
+				generation.error(extractErrorInfo(error));
+				generation.end();
+			}
+
+			// Log error details
+			console.error("[MaximSDK] doStream failed:", error);
+
+			// Flush logs before throwing error (non-blocking where possible)
+			await scheduleLoggerFlush(this.logger);
+
+			throw error;
+		} finally {
+			// End trace if:
+			// 1. User explicitly provided traceId (they manage it) - but don't reset state
+			// 2. OR response has no tool calls (sequence is complete or single call)
+
+			// Reset state when ending trace (only if user didn't provide traceId)
+			// Note: hasToolCallsInResponse is not available here, so we check isInToolCallSequence
+			if (!this.isInToolCallSequence) {
+				// Reset attachment tracking when sequence is complete
+				this.addedAttachmentHashes.clear();
+			}
+			this.currentTraceId = null;
+			this.currentTrace = null;
+			this.isInToolCallSequence = false;
+			trace.end();
+		}
+	}
+
+	/**
+	 * Returns the model ID of the wrapped model.
+	 *
+	 * @returns The model ID.
+	 */
+	get modelId() {
+		return this.model.modelId;
+	}
+
+	/**
+	 * Returns the provider name of the wrapped model.
+	 *
+	 * @returns The provider name.
+	 */
+	get provider() {
+		return this.model.provider;
+	}
+
+	/**
+	 * Returns the specification version of the wrapped model.
+	 *
+	 * @returns The specification version.
+	 */
+	get specificationVersion() {
+		return this.model.specificationVersion;
+	}
+
+	/**
+	 * Supported URL patterns by media type for the provider.
+	 *
+	 * @returns A map of supported URL patterns by media type (as a promise or a plain object).
+	 */
+	get supportedUrls() {
+		return this.model.supportedUrls;
+	}
+
+	/**
+	 * Creates a simple hash of a buffer for duplicate detection.
+	 * Uses a combination of buffer length and a sample of the data.
+	 *
+	 * @private
+	 * @param buffer - The buffer to hash
+	 * @returns A hash string identifying the buffer
+	 */
+	private hashBuffer(buffer: Buffer): string {
+		// Use length and first/last bytes for a simple but effective hash
+		// This is sufficient for duplicate detection without being too expensive
+		const length = buffer.length;
+		const firstBytes = buffer.slice(0, Math.min(16, length)).toString("hex");
+		const lastBytes = length > 16 ? buffer.slice(-16).toString("hex") : "";
+		const middleBytes = length > 32 ? buffer.slice(Math.floor(length / 2) - 8, Math.floor(length / 2) + 8).toString("hex") : "";
+		return `${length}:${firstBytes}:${middleBytes}:${lastBytes}`;
+	}
+}


### PR DESCRIPTION
### TL;DR

Adds support for the Vercel AI SDK `LanguageModelV4` specification (AI SDK 7), enabling Maxim tracing and logging for models using the v4 provider interface.

### What changed?

- Added `ai-sdk-provider-v4` as a dev dependency alias pointing to `@ai-sdk/provider@^4.0.0`.
- Introduced `MaximAISDKWrapperV4`, a new wrapper class implementing `LanguageModelV4` that intercepts `doGenerate` and `doStream` calls to log generations, tool calls, attachments, errors, and performance metrics to Maxim.
- Extended `wrapMaximAISDKModel` to route models with `specificationVersion === "v4"` to the new wrapper.
- Added `parsePromptMessagesV4` to handle the v4 file-data tagged discriminated union (`{ type: 'data' | 'url' | 'text' | 'reference' }`), which differs from the bare `Uint8Array | string | URL` used in v3.
- Added `convertDoGenerateResultToChatCompletionResultV4` and `processStreamV4` to adapt v4 generate/stream results into the internal `ChatCompletionResult` format, including handling v4's unified finish reason shape and token usage fields (`inputTokens.total`, `outputTokens.total`).
- Extended shared utilities (`extractModelParameters`, `extractMaximMetadataFromOptions`, `parseToolResultOutput`) to accept v4 types, and added handling for the new `execution-denied` tool result type introduced in v4.
- Added mock-based unit tests covering routing, `doGenerate`, `doStream`, and all v4 file-data variants (URL, raw bytes, base64 data URI, inline text).
- Added integration tests covering OpenAI and Anthropic v4 models across text generation, streaming, structured output, tool calls, multi-modal input, sessions, multi-turn conversations, error handling, and concurrent calls.

### How to test?

Run the self-contained mock tests without any API keys:

```
npx jest src/lib/logger/vercel/v4/vercelLoggerV4.mock.test.ts --verbose
```

For integration tests, set the required environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MAXIM_API_KEY`, `MAXIM_LOG_REPO_ID`) and run:

```
npx jest src/lib/logger/vercel/v4/vercelLoggerV4.test.ts --verbose
```

### Why make this change?

AI SDK 7 ships a new `LanguageModelV4` provider specification with breaking changes to file part payloads, token usage shapes, finish reason structures, and a new `execution-denied` tool result type. Without this wrapper, any model returning `specificationVersion === "v4"` would fall through to the unsupported-model error path and produce no Maxim traces.