### PR TITLE
chore: version bump and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,11 @@ For projects still using our separate package [Maxim Langchain Tracer](https://w
 
 ## Version changelog
 
+### v6.31.0
+
+- fix: Adds handler support for long-running streams on cloud platforms
+- feat: Add AI SDK v7 support
+
 ### v6.30.2
 
 - feat: Adds support for `simulation` with `yieldsOutput`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@maximai/maxim-js",
 	"description": "Maxim AI JS SDK. Visit https://getmaxim.ai for more info.",
-	"version": "6.30.2",
+	"version": "6.31.0",
 	"scripts": {
 		"build": "npx tsc -p tsconfig.lib.json && npm run copy-assets && npm run clean-package",
 		"copy-assets": "copyfiles \"README.md\" \"LICENSE\" dist",


### PR DESCRIPTION
### TL;DR

Bumps the SDK to v6.31.0 with fixes for long-running streams and AI SDK v7 support.

### What changed?

- Added a handler to properly support long-running streams on cloud platforms, preventing premature stream termination.
- Introduced support for AI SDK v7.

### How to test?

- Run a long-running stream on a cloud platform (e.g., AWS Lambda, Vercel) and verify the stream completes without being cut off.
- Integrate with AI SDK v7 and confirm compatibility with the SDK's streaming and generation features.

### Why make this change?

Cloud platforms often have constraints around long-running connections, requiring explicit handling to keep streams alive. Additionally, AI SDK v7 introduced breaking changes that required updates to maintain compatibility.